### PR TITLE
Prepare AudioEngine upfront

### DIFF
--- a/Decimus/AudioPlayer.swift
+++ b/Decimus/AudioPlayer.swift
@@ -12,15 +12,11 @@ class AudioPlayer {
 
     /// Create a new `AudioPlayer`
     init(fileWrite: Bool) {
-        do {
-            mixerFormat = mixer.inputFormat(forBus: 0)
-            engine.attach(mixer)
-            engine.connect(mixer, to: engine.outputNode, format: mixerFormat)
-            try engine.start()
-            self.fileWrite = fileWrite
-        } catch {
-            fatalError(error.localizedDescription)
-        }
+        mixerFormat = mixer.inputFormat(forBus: 0)
+        engine.attach(mixer)
+        engine.connect(mixer, to: engine.outputNode, format: mixerFormat)
+        engine.prepare()
+        self.fileWrite = fileWrite
     }
 
     deinit {


### PR DESCRIPTION
This seems to reliably fix the crashes on audioengine start for me. Repro was join really locally and see a crash most of the time. Now I cannot get it to crash. The real diff here is just instead of starting upfront, we just prepare. `.prepare()` cannot throw like `.start()` can so removed the do-catch block. 