### PR TITLE
Cache native build

### DIFF
--- a/ci_scripts/ci_post_clone.sh
+++ b/ci_scripts/ci_post_clone.sh
@@ -3,6 +3,10 @@
 # Skip package validation for build plugins.
 defaults write com.apple.dt.Xcode IDESkipPackagePluginFingerprintValidatation -bool YES
 
+# Restore homebrew cache
+export BREW_PATH=$(brew --cache)
+cp -r $CI_DERIVED_DATA_PATH/homebrew $BREW_PATH
+
 # Build tools
 brew install cmake
 brew install pkg-config

--- a/ci_scripts/ci_post_xcodebuild.sh
+++ b/ci_scripts/ci_post_xcodebuild.sh
@@ -1,3 +1,7 @@
+# Cache homebrew.
+export BREW_PATH=$(brew --cache)
+cp -r $BREW_PATH $CI_DERIVED_DATA_PATH/homebrew
+
 # Cache native dependency build folders.
 echo "Caching QMedia build-catalyst"
 cp -r $CI_WORKSPACE/dependencies/build-catalyst $CI_DERIVED_DATA_PATH/$CI_PRODUCT_PLATFORM/build-catalyst


### PR DESCRIPTION
Xcode cloud's derived data folder gets cached, so by moving the native dependency cmake build folders there and restoring them on the next build, we can get incremental builds for PR builds. Not that deploys will not benefit as they don't restore by design. 