### PR TITLE
Extract audio player to protocol

### DIFF
--- a/ApplicationModes/ApplicationMode.swift
+++ b/ApplicationModes/ApplicationMode.swift
@@ -43,7 +43,7 @@ class ApplicationModeBase: ApplicationMode, Hashable {
 
     required init(errorWriter: ErrorWriter) {
         self.errorHandler = errorWriter
-        self.player = AudioPlayer(errorWriter: errorWriter)
+        self.player = AVEngineAudioPlayer(errorWriter: errorWriter)
         self.pipeline = .init(
             decodedCallback: {[weak self] identifier, decoded, _, orientation, verticalMirror in
                 guard let mode = self else { return }

--- a/Decimus.xcodeproj/project.pbxproj
+++ b/Decimus.xcodeproj/project.pbxproj
@@ -21,10 +21,11 @@
 		9B4806812980170B0040F5D4 /* H264Encoder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B4806802980170B0040F5D4 /* H264Encoder.swift */; };
 		9B4806832981D4400040F5D4 /* AudioEncoder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B4806822981D4400040F5D4 /* AudioEncoder.swift */; };
 		9B480685298284F40040F5D4 /* OpusDecoder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B480684298284F40040F5D4 /* OpusDecoder.swift */; };
-		9B480687298289910040F5D4 /* AudioPlayer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B480686298289910040F5D4 /* AudioPlayer.swift */; };
+		9B480687298289910040F5D4 /* AVEngineAudioPlayer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B480686298289910040F5D4 /* AVEngineAudioPlayer.swift */; };
 		9B48068929829FB90040F5D4 /* VideoParticipant.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B48068829829FB90040F5D4 /* VideoParticipant.swift */; };
 		9B48068C298301FD0040F5D4 /* QMedia.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B48068B298301FD0040F5D4 /* QMedia.swift */; };
 		9B555198299B8B4F0025906D /* RawLoopback.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B555197299B8B4F0025906D /* RawLoopback.swift */; };
+		9B5992B62A02A2C3009B899E /* AudioPlayer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B5992B52A02A2C3009B899E /* AudioPlayer.swift */; };
 		9B647C9C29A6267B000AD358 /* PCMExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B647C9B29A6267B000AD358 /* PCMExtensions.swift */; };
 		9B76FFE2298D5566006B5267 /* neo_media_client.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9B76FFE1298D5566006B5267 /* neo_media_client.xcframework */; };
 		9B76FFE3298D5570006B5267 /* neo_media_client.xcframework in Embed Libraries */ = {isa = PBXBuildFile; fileRef = 9B76FFE1298D5566006B5267 /* neo_media_client.xcframework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
@@ -128,11 +129,12 @@
 		9B4806802980170B0040F5D4 /* H264Encoder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = H264Encoder.swift; sourceTree = "<group>"; };
 		9B4806822981D4400040F5D4 /* AudioEncoder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AudioEncoder.swift; sourceTree = "<group>"; };
 		9B480684298284F40040F5D4 /* OpusDecoder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OpusDecoder.swift; sourceTree = "<group>"; };
-		9B480686298289910040F5D4 /* AudioPlayer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AudioPlayer.swift; sourceTree = "<group>"; };
+		9B480686298289910040F5D4 /* AVEngineAudioPlayer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AVEngineAudioPlayer.swift; sourceTree = "<group>"; };
 		9B48068829829FB90040F5D4 /* VideoParticipant.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VideoParticipant.swift; sourceTree = "<group>"; };
 		9B48068B298301FD0040F5D4 /* QMedia.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QMedia.swift; sourceTree = "<group>"; };
 		9B48068D29830CCB0040F5D4 /* Decimus-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "Decimus-Bridging-Header.h"; sourceTree = "<group>"; };
 		9B555197299B8B4F0025906D /* RawLoopback.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RawLoopback.swift; sourceTree = "<group>"; };
+		9B5992B52A02A2C3009B899E /* AudioPlayer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AudioPlayer.swift; sourceTree = "<group>"; };
 		9B647C9B29A6267B000AD358 /* PCMExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PCMExtensions.swift; sourceTree = "<group>"; };
 		9B76FFE1298D5566006B5267 /* neo_media_client.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = neo_media_client.xcframework; path = dependencies/neo_media_client.xcframework; sourceTree = "<group>"; };
 		9B85951429F03147008C813C /* TestPlan.xctestplan */ = {isa = PBXFileReference; lastKnownFileType = text; path = TestPlan.xctestplan; sourceTree = "<group>"; };
@@ -312,9 +314,10 @@
 				9B480669297EFF040040F5D4 /* DecoderElement.swift */,
 				9B48066B297F051D0040F5D4 /* EncoderElement.swift */,
 				9B48066D297F19700040F5D4 /* CaptureManager.swift */,
-				9B480686298289910040F5D4 /* AudioPlayer.swift */,
+				9B480686298289910040F5D4 /* AVEngineAudioPlayer.swift */,
 				9BDD5AF52996736B00C01D54 /* SampleExtensions.swift */,
 				9BAD55BC29B0B77700D9B65F /* ErrorWriter.swift */,
+				9B5992B52A02A2C3009B899E /* AudioPlayer.swift */,
 			);
 			path = Decimus;
 			sourceTree = "<group>";
@@ -605,7 +608,7 @@
 				9B165A132984012D0017079F /* ApplicationMode.swift in Sources */,
 				9B4806812980170B0040F5D4 /* H264Encoder.swift in Sources */,
 				FFBF2FB729BFE48100D769CF /* ActionButton.swift in Sources */,
-				9B480687298289910040F5D4 /* AudioPlayer.swift in Sources */,
+				9B480687298289910040F5D4 /* AVEngineAudioPlayer.swift in Sources */,
 				9B48066C297F051D0040F5D4 /* EncoderElement.swift in Sources */,
 				FF4DA06D29FAEF4F00A01E5D /* ViewExtensions.swift in Sources */,
 				9BDD5AF62996736B00C01D54 /* SampleExtensions.swift in Sources */,
@@ -617,6 +620,7 @@
 				9BDD5AF42996732E00C01D54 /* MediaBuffer.swift in Sources */,
 				FFB8CBE529C148B70093C623 /* ActionPicker.swift in Sources */,
 				9BAD55BD29B0B77700D9B65F /* ErrorWriter.swift in Sources */,
+				9B5992B62A02A2C3009B899E /* AudioPlayer.swift in Sources */,
 				9BDD5AEE2996414400C01D54 /* PassthroughDecoder.swift in Sources */,
 				9B555198299B8B4F0025906D /* RawLoopback.swift in Sources */,
 				9B48066E297F19700040F5D4 /* CaptureManager.swift in Sources */,

--- a/Decimus/AVEngineAudioPlayer.swift
+++ b/Decimus/AVEngineAudioPlayer.swift
@@ -1,0 +1,103 @@
+import AVFoundation
+
+/// Plays audio samples out.
+class AVEngineAudioPlayer: AudioPlayer {
+    private var engine: AVAudioEngine! = .init()
+    private var mixer: AVAudioMixerNode! = .init()
+    private let mixerFormat: AVAudioFormat
+    private let errorWriter: ErrorWriter
+    private var players: [UInt32: AVAudioPlayerNode] = [:]
+
+    /// Create a new `AudioPlayer`
+    init(errorWriter: ErrorWriter) {
+        self.errorWriter = errorWriter
+
+        mixerFormat = mixer.inputFormat(forBus: 0)
+        engine.attach(mixer)
+        engine.connect(mixer, to: engine.outputNode, format: mixerFormat)
+        engine.prepare()
+    }
+
+    deinit {
+        players.forEach { _, player in
+            player.stop()
+        }
+        engine.stop()
+
+        players.forEach { _, player in
+            engine.disconnectNodeInput(player)
+            engine.detach(player)
+        }
+        players.removeAll()
+
+        engine.disconnectNodeInput(mixer)
+        engine.detach(mixer)
+
+        mixer = nil
+        engine = nil
+    }
+
+    func write(identifier: UInt32, buffer: AVAudioPCMBuffer) {
+        guard mixerFormat.commonFormat == .pcmFormatFloat32 else {
+            errorWriter.writeError(message: "Currently expecting output as F32")
+            return
+        }
+
+        let inputBuffer: AVAudioPCMBuffer
+        switch buffer.format.commonFormat {
+        case .pcmFormatFloat32:
+            inputBuffer = buffer
+        case .pcmFormatInt16:
+            // Mixer cannot handle int16 -> float conversion.
+            inputBuffer = buffer.asFloat()
+        default:
+            errorWriter.writeError(message: "Unsupported input format")
+            return
+        }
+
+        // Get the player node for this stream.
+        var node: AVAudioPlayerNode? = players[identifier]
+        if node == nil {
+            do {
+                node = try createPlayer(identifier: identifier, inputFormat: inputBuffer.format)
+            } catch {
+                errorWriter.writeError(message: error.localizedDescription)
+                return
+            }
+        }
+
+        // Play the buffer.
+        node!.scheduleBuffer(inputBuffer)
+    }
+
+    private func createPlayer(identifier: UInt32, inputFormat: AVAudioFormat) throws -> AVAudioPlayerNode {
+        guard players[identifier] == nil else { fatalError() }
+        print("AudioPlayer => [\(identifier)] New player: \(inputFormat)")
+        if !engine.isRunning {
+            try engine.start()
+        }
+
+        let node: AVAudioPlayerNode = .init()
+        engine.attach(node)
+        engine.connect(node, to: mixer, format: inputFormat)
+        node.play()
+
+        let inputRate = inputFormat.sampleRate
+        let outputRate = node.outputFormat(forBus: 0).sampleRate
+        guard outputRate == inputRate else {
+            fatalError("AVAudioEngine expects these sample rates match. Out: \(outputRate) In: \(inputRate)")
+        }
+
+        players[identifier] = node
+        return node
+    }
+
+    func removePlayer(identifier: UInt32) {
+        guard let player = players[identifier] else { return }
+
+        player.stop()
+        engine.disconnectNodeInput(player)
+        engine.detach(player)
+        players.removeValue(forKey: identifier)
+    }
+}

--- a/Decimus/AudioPlayer.swift
+++ b/Decimus/AudioPlayer.swift
@@ -1,103 +1,13 @@
-import AVFoundation
+import AVFAudio
 
-/// Plays audio samples out.
-class AudioPlayer {
-    private var engine: AVAudioEngine! = .init()
-    private var mixer: AVAudioMixerNode! = .init()
-    private let mixerFormat: AVAudioFormat
-    private let errorWriter: ErrorWriter
-    private var players: [UInt32: AVAudioPlayerNode] = [:]
+/// Represents the ability to mix and play multiple streams of audio.
+protocol AudioPlayer {
+    /// Write some audio to be played.
+    /// - Parameter identifier: The unique identifier for this stream.
+    /// - Parameter buffer: The buffer of audio data.
+    func write(identifier: UInt32, buffer: AVAudioPCMBuffer)
 
-    /// Create a new `AudioPlayer`
-    init(errorWriter: ErrorWriter) {
-        self.errorWriter = errorWriter
-
-        mixerFormat = mixer.inputFormat(forBus: 0)
-        engine.attach(mixer)
-        engine.connect(mixer, to: engine.outputNode, format: mixerFormat)
-        engine.prepare()
-    }
-
-    deinit {
-        players.forEach { _, player in
-            player.stop()
-        }
-        engine.stop()
-
-        players.forEach { _, player in
-            engine.disconnectNodeInput(player)
-            engine.detach(player)
-        }
-        players.removeAll()
-
-        engine.disconnectNodeInput(mixer)
-        engine.detach(mixer)
-
-        mixer = nil
-        engine = nil
-    }
-
-    func write(identifier: UInt32, buffer: AVAudioPCMBuffer) {
-        guard mixerFormat.commonFormat == .pcmFormatFloat32 else {
-            errorWriter.writeError(message: "Currently expecting output as F32")
-            return
-        }
-
-        let inputBuffer: AVAudioPCMBuffer
-        switch buffer.format.commonFormat {
-        case .pcmFormatFloat32:
-            inputBuffer = buffer
-        case .pcmFormatInt16:
-            // Mixer cannot handle int16 -> float conversion.
-            inputBuffer = buffer.asFloat()
-        default:
-            errorWriter.writeError(message: "Unsupported input format")
-            return
-        }
-
-        // Get the player node for this stream.
-        var node: AVAudioPlayerNode? = players[identifier]
-        if node == nil {
-            do {
-                node = try createPlayer(identifier: identifier, inputFormat: inputBuffer.format)
-            } catch {
-                errorWriter.writeError(message: error.localizedDescription)
-                return
-            }
-        }
-
-        // Play the buffer.
-        node!.scheduleBuffer(inputBuffer)
-    }
-
-    private func createPlayer(identifier: UInt32, inputFormat: AVAudioFormat) throws -> AVAudioPlayerNode {
-        guard players[identifier] == nil else { fatalError() }
-        print("AudioPlayer => [\(identifier)] New player: \(inputFormat)")
-        if !engine.isRunning {
-            try engine.start()
-        }
-
-        let node: AVAudioPlayerNode = .init()
-        engine.attach(node)
-        engine.connect(node, to: mixer, format: inputFormat)
-        node.play()
-
-        let inputRate = inputFormat.sampleRate
-        let outputRate = node.outputFormat(forBus: 0).sampleRate
-        guard outputRate == inputRate else {
-            fatalError("AVAudioEngine expects these sample rates match. Out: \(outputRate) In: \(inputRate)")
-        }
-
-        players[identifier] = node
-        return node
-    }
-
-    func removePlayer(identifier: UInt32) {
-        guard let player = players[identifier] else { return }
-
-        player.stop()
-        engine.disconnectNodeInput(player)
-        engine.detach(player)
-        players.removeValue(forKey: identifier)
-    }
+    /// Remove a stream from the player.
+    /// - Parameter identifier: Identifier of the stream to remove.
+    func removePlayer(identifier: UInt32)
 }


### PR DESCRIPTION
Pushing some groundwork for incoming audio unit code. Diff looks messy because the file and class name `AudioPlayer` has been repurposed as the protocol name. The real addition is just the new protocol, the single line to make the existing one conform, and the single line change of the init. 