### PR TITLE
Protect element access with spinlock

### DIFF
--- a/Decimus/FasterAVEngineAudioPlayer.swift
+++ b/Decimus/FasterAVEngineAudioPlayer.swift
@@ -240,7 +240,7 @@ class FasterAVEngineAudioPlayer: AudioPlayer {
             }
         }
 
-        guard var element = elements.removeValue(forKey: identifier) else { fatalError("No player for: \(identifier)") }
+        guard var element = elements.removeValue(forKey: identifier) else { return }
         print("[FasterAVAudioEngine] Removing \(identifier)")
 
         // Dispose of the element's resources.


### PR DESCRIPTION
Fair warning - I don't really know what I'm doing here.

There was an issue with concurrent dictionary access during lookup for the right buffer for the given source node. We shouldn't attempt to take a mutex during the realtime callback, so I've attempted to implement a spin lock (that won't actually *spin* on the audio thread - will just immediately return silence if it can't set the flag). Not sure what the best approach is here - any measured contention is very low though, and I don't really see any impact to the audio. Proably lots to unpack here - I think we should be in C/C++ anyway - but this gets rid of the crash for now. 