### PR TITLE
Create audio players upfront with correct formats

### DIFF
--- a/ApplicationModes/ApplicationMode.swift
+++ b/ApplicationModes/ApplicationMode.swift
@@ -31,7 +31,11 @@ class ApplicationModeBase: ApplicationMode, Hashable {
 
     private let id = UUID()
 
-    required init(errorWriter: ErrorWriter, player: AudioPlayer, metricsSubmitter: MetricsSubmitter) {
+    required init(errorWriter: ErrorWriter,
+                  player: AudioPlayer,
+                  metricsSubmitter: MetricsSubmitter,
+                  inputAudioFormat: AVAudioFormat,
+                  outputAudioFormat: AVAudioFormat) {
         self.errorHandler = errorWriter
         self.player = player
         self.pipeline = .init(errorWriter: errorWriter, metricsSubmitter: metricsSubmitter)
@@ -45,7 +49,7 @@ class ApplicationModeBase: ApplicationMode, Hashable {
             }
         }
 
-        CodecFactory.shared = .init()
+        CodecFactory.shared = .init(inputAudioFormat: inputAudioFormat, outputAudioFormat: outputAudioFormat)
         CodecFactory.shared.registerEncoderCallback { [weak self] id, media in
             guard let mode = self else { return }
             let identified: MediaBufferFromSource = .init(source: id, media: media)

--- a/ApplicationModes/Loopback.swift
+++ b/ApplicationModes/Loopback.swift
@@ -27,7 +27,9 @@ class Loopback: ApplicationModeBase {
             }
 
             pipeline!.registerEncoder(identifier: device.id, config: config)
-            pipeline!.registerDecoder(identifier: device.id, config: config)
+            if let decoder = pipeline!.registerDecoder(identifier: device.id, config: config) as? BufferDecoder {
+                player.addPlayer(identifier: device.id, format: decoder.decodedFormat)
+            }
         case .removed:
             pipeline!.unregisterEncoder(identifier: device.id)
             pipeline!.unregisterDecoder(identifier: device.id)

--- a/ApplicationModes/QMediaPubSub.swift
+++ b/ApplicationModes/QMediaPubSub.swift
@@ -92,7 +92,10 @@ class QMediaPubSub: ApplicationModeBase {
                                                        callback: streamCallback)
         streamIdMap.append(streamId)
 
-        self.pipeline!.registerDecoder(identifier: streamId, config: config)
+        let decoder = self.pipeline!.registerDecoder(identifier: streamId, config: config)
+        if let decoder = decoder as? BufferDecoder {
+            self.player.addPlayer(identifier: streamId, format: decoder.decodedFormat)
+        }
         print("[QMediaPubSub] Subscribed to \(String(describing: config.codec)) stream: \(streamId)")
     }
 

--- a/Decimus/AudioPlayer.swift
+++ b/Decimus/AudioPlayer.swift
@@ -2,10 +2,21 @@ import AVFAudio
 
 /// Represents the ability to mix and play multiple streams of audio.
 protocol AudioPlayer {
+
+    /// The format that the player desires input in.
+    /// This may not be a requirement depending on the implementation,
+    /// but it may be optimal to provide audio in the desired format where possible.
+    var inputFormat: AVAudioFormat { get }
+
     /// Write some audio to be played.
     /// - Parameter identifier: The unique identifier for this stream.
     /// - Parameter buffer: The buffer of audio data.
     func write(identifier: UInt64, buffer: AVAudioPCMBuffer)
+
+    /// Add a player element for the given stream.
+    /// - Parameter identifier: The unique identifier for this stream.
+    /// - Parameter format: The expected format audio for this stream will arrive in.
+    func addPlayer(identifier: UInt64, format: AVAudioFormat)
 
     /// Remove a stream from the player.
     /// - Parameter identifier: Identifier of the stream to remove.

--- a/Decimus/AudioUnit/AudioUnitHelpers.swift
+++ b/Decimus/AudioUnit/AudioUnitHelpers.swift
@@ -106,6 +106,15 @@ extension AudioUnit {
         }
 
         // This is the actual format being output/requested for input.
+        return try getFormat(microphone: microphone)
+    }
+
+    /// Get the desired format to the application controllable format of the audio unit.
+    /// For a microphone, this is the output side of the input bus.
+    /// For a speaker, this is the input side of the output bus.
+    /// - Parameter microphone: True if this is the microphone side per the above, false if speaker.
+    /// - Returns The format in use.
+    func getFormat(microphone: Bool) throws -> AudioStreamBasicDescription {
         var retrievedActualFormat: AudioStreamBasicDescription = .init()
         var retrievedActualFormatSize: UInt32 = UInt32(MemoryLayout.size(ofValue: retrievedActualFormat))
         let getFormat = AudioUnitGetProperty(self,

--- a/Decimus/CaptureManager.swift
+++ b/Decimus/CaptureManager.swift
@@ -261,6 +261,17 @@ actor CaptureManager: NSObject,
 
         // Callback this media sample.
         if output == audioOutput {
+            guard let asbd = sampleBuffer.formatDescription?.audioStreamBasicDescription else {
+                errorHandler.writeError(message: "Couldn't get audio input format")
+                return
+            }
+
+            guard asbd.mSampleRate == .opus48khz,
+                  asbd.mChannelsPerFrame == 1,
+                  asbd.mBytesPerFrame == 2 else {
+                errorHandler.writeError(message: "Microphone format not currently supported. Try a different mic")
+                return
+            }
             audioFrameCallback(device!.id, sampleBuffer)
         } else {
             cameraFrameCallback(device!.id, sampleBuffer)

--- a/Decimus/Codec/LibOpusDecoder.swift
+++ b/Decimus/Codec/LibOpusDecoder.swift
@@ -6,21 +6,13 @@ class LibOpusDecoder: BufferDecoder {
 
     private let decoder: Opus.Decoder
     internal var callback: DecodedBufferCallback?
-    private let format: AVAudioFormat
+    let decodedFormat: AVAudioFormat
 
-    /// Create an opus decoder with the given input format.
-    /// - Parameter format: The incoming opus format.
-    /// - Parameter fileWrite: True to write decoded audio to a file (debugging).
-    /// - Parameter errorWriter: Protocol to report errors to.
-    /// - Parameter callback: A callback fired when decoded data becomes available.
-    init(format: AVAudioFormat) {
-        self.format = format
-        do {
-            guard format.isValidOpusPCMFormat else { fatalError() }
-            decoder = try .init(format: format, application: .voip)
-        } catch {
-            fatalError("Opus => Unsupported format?")
-        }
+    /// Create an opus decoder.
+    /// - Parameter format: Format to decode into.
+    init(format: AVAudioFormat) throws {
+        self.decodedFormat = format
+        decoder = try .init(format: format, application: .voip)
     }
 
     /// Write some encoded data to the decoder.
@@ -34,7 +26,7 @@ class LibOpusDecoder: BufferDecoder {
         let ubp: UnsafeBufferPointer<UInt8> = .init(start: unsafe, count: data.count)
 
         // Create buffer for the decoded data.
-        let decoded: AVAudioPCMBuffer = .init(pcmFormat: format,
+        let decoded: AVAudioPCMBuffer = .init(pcmFormat: decodedFormat,
                                               frameCapacity: .opusMax)!
         do {
             try decoder.decode(ubp, to: decoded)

--- a/Decimus/Codec/PCMExtensions.swift
+++ b/Decimus/Codec/PCMExtensions.swift
@@ -44,3 +44,14 @@ extension Array<UInt8> {
         }
     }
 }
+
+extension AVAudioFormat {
+    func equivalent(other: AVAudioFormat) -> Bool {
+        guard sampleRate == other.sampleRate,
+              commonFormat == other.commonFormat,
+              channelCount == other.channelCount else {
+            return false
+        }
+        return channelCount > 1 ? isInterleaved == other.isInterleaved : true
+    }
+}

--- a/Decimus/FasterAVEngineAudioPlayer.swift
+++ b/Decimus/FasterAVEngineAudioPlayer.swift
@@ -4,6 +4,7 @@ import CTPCircularBuffer
 
 /// Plays audio samples out.
 class FasterAVEngineAudioPlayer: AudioPlayer {
+    let inputFormat: AVAudioFormat
     private var engine: AVAudioEngine = .init()
     private var mixer: AVAudioMixerNode = .init()
     private let errorWriter: ErrorWriter
@@ -14,6 +15,8 @@ class FasterAVEngineAudioPlayer: AudioPlayer {
         self.errorWriter = errorWriter
 
         engine.attach(mixer)
+        inputFormat = mixer.inputFormat(forBus: 0)
+        print("[FasterAVEngineAudioPlayer] Creating. Mixer input format is: \(inputFormat)")
         engine.connect(mixer, to: engine.outputNode, format: nil)
         engine.prepare()
     }
@@ -32,35 +35,37 @@ class FasterAVEngineAudioPlayer: AudioPlayer {
 
     func write(identifier: UInt64, buffer: AVAudioPCMBuffer) {
         // Get the source element for this identifier.
-        let source: SourceElement
-        let indeterminate: SourceElement? = elements[identifier]
-        if indeterminate == nil {
-            // TODO: Creation on demand will go away with prepare() / manifests.
-            do {
-                if !engine.isRunning {
-                    try engine.start()
-                }
-            } catch {
-                self.errorWriter.writeError(message: "Couldn't start audio engine")
-            }
-
-            // Create a node for this source and add it to the mixer.
-            source = .init(format: buffer.format)
-            elements[identifier] = source
-            engine.attach(source.sourceNode)
-            engine.connect(source.sourceNode, to: mixer, format: nil)
-        } else {
-            source = indeterminate!
+        let source: SourceElement? = elements[identifier]
+        guard let source = source else {
+            errorWriter.writeError(message: "Missing player for: \(identifier)")
+            return
         }
 
         // Copy data into the source's input buffer.
         source.write(list: buffer.mutableAudioBufferList)
     }
 
+    func addPlayer(identifier: UInt64, format: AVAudioFormat) {
+        do {
+            if !engine.isRunning {
+                try engine.start()
+            }
+        } catch {
+            self.errorWriter.writeError(message: "Couldn't start audio engine")
+        }
+
+        // Create a node for this source and add it to the mixer.
+        let source: SourceElement = .init(format: format)
+        print("[FasterAVAudioEngine] (\(identifier)) Creating element: \(format)")
+        elements[identifier] = source
+        engine.attach(source.sourceNode)
+        engine.connect(source.sourceNode, to: mixer, format: nil)
+    }
+
     func removePlayer(identifier: UInt64) {
 
         guard let element = elements.removeValue(forKey: identifier) else { return }
-        print("[FasterAVAudioEngine] Removing \(identifier)")
+        print("[FasterAVAudioEngine] (\(identifier)) Removing")
 
         // Dispose of the element's resources.
         engine.disconnectNodeInput(element.sourceNode)

--- a/Decimus/Models/Decoder.swift
+++ b/Decimus/Models/Decoder.swift
@@ -22,6 +22,7 @@ extension SampleDecoder {
 protocol BufferDecoder: Decoder {
     typealias DecodedBufferCallback = (_ buffer: AVAudioPCMBuffer, _ timestamp: CMTime) -> Void
     var callback: DecodedBufferCallback? {get set}
+    var decodedFormat: AVAudioFormat {get}
 
     mutating func registerCallback(callback: @escaping DecodedBufferCallback)
 }

--- a/Decimus/PipelineManager.swift
+++ b/Decimus/PipelineManager.swift
@@ -52,12 +52,13 @@ class PipelineManager {
                                      submitter: metricsSubmitter)
     }
 
-    func registerDecoder(identifier: UInt64, config: CodecConfig) {
-        let decoder = CodecFactory.shared.createDecoder(identifier: identifier, config: config)
-        guard decoders[identifier] == nil else {
-            return
+    func registerDecoder(identifier: UInt64, config: CodecConfig) -> Decoder {
+        guard let decoder = self.decoders[identifier] else {
+            let decoder = CodecFactory.shared.createDecoder(identifier: identifier, config: config)
+            decoders[identifier] = decoder
+            return decoder
         }
-        decoders[identifier] = decoder
+        return decoder
     }
 
     func unregisterEncoder(identifier: UInt64) {


### PR DESCRIPTION
Create audio players upfront with the correct audio formats. There is a bit of a dance here in order to be able to optimally do things upfront. The decoders previously would spit out audio data and a player would be created when the first decoded audio arrived, from whatever format the decoder spat it out in. 


Now, decoders will first query the player that will be used to play out their audio to find out what their desired input (for output) format is. If it's something than can be decoded directly into, it will be used. Otherwise the standard decode of 48k, float32, stereo will be used. In that case, the player will have to convert this audio if it needs to. This is intended to:

- Do as much upfront initialization as possible, rather than on receipt of media.
- Skip any format conversions that are not needed as early as possible. 
- Properly handle providing output audio in the right formats or converting if required. 

There seems to be a drawback of AVCaptureDevice for microphones where the formats/activeFormat property is nil. As a result, right now it's hardcoded to what the Mac and iPhone built-in microphone produces. In a subsequent PR I will change audio input to come from AVAudioEngine instead. The "real" format will be available there upfront, and we can provide it properly. Most of the scaffolding for that is already present here - just using a hardcoded value instead. 