### PR TITLE
Sync flush video codecs on deinit

### DIFF
--- a/Decimus/Codec/H264Decoder.swift
+++ b/Decimus/Codec/H264Decoder.swift
@@ -30,8 +30,11 @@ class H264Decoder: SampleDecoder {
 
     deinit {
         guard let session = self.session else { return }
+        let flush = VTDecompressionSessionWaitForAsynchronousFrames(session)
+        if flush != .zero {
+            print("H264Decoder failed to flush frames")
+        }
         VTDecompressionSessionInvalidate(session)
-        self.session = nil
     }
 
     /// Write a new frame to the decoder.

--- a/Decimus/Codec/H264Encoder.swift
+++ b/Decimus/Codec/H264Encoder.swift
@@ -51,8 +51,15 @@ class H264Encoder: Encoder {
 
     deinit {
         guard let session = encoder else { return }
+
+        // Sync flush all pending frames.
+        let flushError = VTCompressionSessionCompleteFrames(session,
+                                                            untilPresentationTimeStamp: .init())
+        if flushError != .zero {
+            print("H264 Encoder failed to flush")
+        }
+
         VTCompressionSessionInvalidate(session)
-        self.encoder = nil
     }
 
     func write(sample: CMSampleBuffer) {


### PR DESCRIPTION
Force H264 codecs to emit all pending frames on deinit for a more deterministic teardown