### PR TITLE
Fix vertical mirror

### DIFF
--- a/Decimus/Publications/H264Publication.swift
+++ b/Decimus/Publications/H264Publication.swift
@@ -70,7 +70,7 @@ class H264Publication: NSObject, AVCaptureDevicePublication, FrameListener {
         }
         #endif
         self.device = device
-        self.encoder = .init(config: config, verticalMirror: device.position == .front)
+        self.encoder = try .init(config: config, verticalMirror: device.position == .front)
         super.init()
 
         self.encoder.registerCallback { [weak self] data, flag in


### PR DESCRIPTION
Somewhere along the line the vertical mirror flag stopped getting set, so front facing cameras would show incorrectly. 