### PR TITLE
Trigger cleanup timer on subscribed object

### DIFF
--- a/Decimus/Subscriptions/H264Subscription.swift
+++ b/Decimus/Subscriptions/H264Subscription.swift
@@ -55,6 +55,15 @@ class H264Subscription: Subscription {
         self.errorWriter = errorWriter
         self.namegate = namegate
 
+        // Create the renderer.
+        DispatchQueue.main.async {
+            do {
+                try self.participants.create(identifier: namespace)
+            } catch {
+                errorWriter.writeError("Failed to create video participant: \(error.localizedDescription)")
+            }
+        }
+
         self.decoder.registerCallback { [weak self] in
             self?.showDecodedImage(decoded: $0, timestamp: $1, orientation: $2, verticalMirror: $3)
         }
@@ -79,6 +88,16 @@ class H264Subscription: Subscription {
         Task(priority: .utility) {
             await self.measurement.receivedFrame(timestamp: now)
             await self.measurement.receivedBytes(received: data.count, timestamp: now)
+        }
+
+        // Let the renderer know we're still here.
+        DispatchQueue.main.async {
+            do {
+                let participant = try self.participants.get(identifier: self.namespace)
+                participant.lastUpdated = .now()
+            } catch {
+                self.errorWriter.writeError("Failed to retrieve video participant: \(error.localizedDescription)")
+            }
         }
 
         // Should we feed this frame to the decoder?
@@ -126,18 +145,21 @@ class H264Subscription: Subscription {
 
         // Enqueue the buffer.
         DispatchQueue.main.async {
-            let participant = self.participants.getOrMake(identifier: self.namespace)
-            guard let layer = participant.view.layer else {
-                fatalError()
+            do {
+                let participant = try self.participants.get(identifier: self.namespace)
+                guard let layer = participant.view.layer else {
+                    fatalError()
+                }
+                guard layer.status != .failed else {
+                    self.log("Layer failed: \(layer.error!)")
+                    layer.flush()
+                    return
+                }
+                layer.transform = orientation?.toTransform(verticalMirror) ?? CATransform3DIdentity
+                layer.enqueue(decoded)
+            } catch {
+                self.errorWriter.writeError("Failed to retrieve video participant: \(error.localizedDescription)")
             }
-            guard layer.status != .failed else {
-                self.log("Layer failed: \(layer.error!)")
-                layer.flush()
-                return
-            }
-            layer.transform = orientation?.toTransform(verticalMirror) ?? CATransform3DIdentity
-            layer.enqueue(decoded)
-            participant.lastUpdated = .now()
         }
     }
 }

--- a/Decimus/Views/Components/VideoGrid.swift
+++ b/Decimus/Views/Components/VideoGrid.swift
@@ -47,8 +47,10 @@ struct VideoGrid: View {
 struct VideoGrid_Previews: PreviewProvider {
     static let exampleParticipants: VideoParticipants = .init()
     init() {
-        _ = VideoGrid_Previews.exampleParticipants.getOrMake(identifier: "1")
-        _ = VideoGrid_Previews.exampleParticipants.getOrMake(identifier: "2")
+        // swiftlint:disable force_try
+        _ = try! VideoGrid_Previews.exampleParticipants.create(identifier: "1")
+        _ = try! VideoGrid_Previews.exampleParticipants.create(identifier: "2")
+        // swiftlint:enable force_try
     }
     static var previews: some View {
         VideoGrid(participants: exampleParticipants)


### PR DESCRIPTION
- Defensive checks

This essentially removes the "see background image until a real image shows up" feature we have today, but the advantage is that the renderer is up and ready for data as early as possible. 