### PR TITLE
Enable async decoding

### DIFF
--- a/Decimus/Codec/H264Decoder.swift
+++ b/Decimus/Codec/H264Decoder.swift
@@ -136,10 +136,12 @@ class H264Decoder: SampleDecoder {
                                  unsafeBitCast(kCFBooleanTrue, to: UnsafeRawPointer.self))
 
             // Pass sample to decoder.
+            var inputFlags: VTDecodeFrameFlags = .init()
+            inputFlags.insert(._EnableAsynchronousDecompression)
             var outputFlags: VTDecodeInfoFlags = .init()
             let decodeError = VTDecompressionSessionDecodeFrame(session!,
                                                                 sampleBuffer: sampleBuffer!,
-                                                                flags: .init(),
+                                                                flags: inputFlags,
                                                                 infoFlagsOut: &outputFlags,
                                                                 outputHandler: self.frameCallback)
 


### PR DESCRIPTION
Allows decode frame call to return before the decode operation is complete. There are some other flags here, like optimizing for never going above 1x playback, and for temporal processing. Not sure if we want them. There is also the don't display flag we could use if we detected bursts in the future. See #115 