### PR TITLE
Fix couple of implicit captures

### DIFF
--- a/Decimus/CaptureManager.swift
+++ b/Decimus/CaptureManager.swift
@@ -78,7 +78,7 @@ class CaptureManager: NSObject, AVCaptureVideoDataOutputSampleBufferDelegate {
         queue.async { [weak self] in
             guard let self = self else { return }
             self.session.startRunning()
-            if let observer = observer {
+            if let observer = self.observer {
                 self.notifier.removeObserver(observer)
             }
         }

--- a/Decimus/Publications/H264Publication.swift
+++ b/Decimus/Publications/H264Publication.swift
@@ -84,7 +84,7 @@ class H264Publication: NSObject, AVCaptureDevicePublication, FrameListener {
             guard let self = self else { return }
 
             let timestamp = Date.now
-            if let measurement = measurement {
+            if let measurement = self.measurement {
                 Task(priority: .utility) {
                     await measurement.sentBytes(sent: UInt64(datalength), timestamp: timestamp)
                 }

--- a/Decimus/Publications/OpusPublication.swift
+++ b/Decimus/Publications/OpusPublication.swift
@@ -108,7 +108,7 @@ class OpusPublication: Publication {
         }
         encoder.registerCallback(callback: { [weak self] data, datalength, flag in
             guard let self = self else { return }
-            if let measurement = measurement {
+            if let measurement = self.measurement {
                 Task(priority: .utility) {
                     await measurement.publishedBytes(sentBytes: datalength, timestamp: nil)
                 }


### PR DESCRIPTION
XCode randomly complained about these (it doesn't normally), but it's right that these are some implicit self captures that should use the unwrapped weak optional instead. 