### PR TITLE
Remove voice processing flag

### DIFF
--- a/Decimus/FasterAVEngineAudioPlayer.swift
+++ b/Decimus/FasterAVEngineAudioPlayer.swift
@@ -14,6 +14,8 @@ class FasterAVEngineAudioPlayer {
 
     /// Create a new `AudioPlayer`
     init(engine: AVAudioEngine) {
+        assert(engine.outputNode.isVoiceProcessingEnabled)
+        assert(engine.outputNode.numberOfInputs == 1)
         let outputFormat = engine.outputNode.inputFormat(forBus: 0)
         inputFormat = .init(commonFormat: outputFormat.commonFormat,
                             sampleRate: .opus48khz,

--- a/Decimus/Subscriptions/SubscriptionFactory.swift
+++ b/Decimus/Subscriptions/SubscriptionFactory.swift
@@ -42,7 +42,6 @@ struct SubscriptionConfig: Codable {
     var jitterDepthTime: TimeInterval
     var opusWindowSize: OpusWindowSize
     var videoBehaviour: VideoBehaviour
-    var voiceProcessing: Bool
     var mediaReliability: MediaReliability
     var quicCwinMinimumKiB: UInt64
     var videoJitterBuffer: Bool
@@ -51,7 +50,6 @@ struct SubscriptionConfig: Codable {
         jitterDepthTime = 0.06
         opusWindowSize = .twentyMs
         videoBehaviour = .freeze
-        voiceProcessing = true
         mediaReliability = .init()
         quicCwinMinimumKiB = 128
         videoJitterBuffer = false

--- a/Decimus/Views/Settings/SubscriptionSettingsView.swift
+++ b/Decimus/Views/Settings/SubscriptionSettingsView.swift
@@ -36,10 +36,6 @@ struct SubscriptionSettingsView: View {
                         }
                     }.pickerStyle(.segmented)
                 }
-                HStack {
-                    Text("Voice Processing")
-                    Toggle(isOn: $subscriptionConfig.value.voiceProcessing) {}
-                }
             }
             .formStyle(.columns)
         }


### PR DESCRIPTION
I had added this flag while we still had issues with voice processing. Since the blocking issues with it have gone, removing it now in order to simplify the audio paths (and aid debugging the remaining issue). 

Handled some optionals with the call controller so I can report throwing issues (although as far as I can tell they should never be hit, but alerts are better than assertions when getting reports from testflight users). 