### PR TITLE
Change ObjC subscription callback type

### DIFF
--- a/Decimus/Codec/LibOpusDecoder.swift
+++ b/Decimus/Codec/LibOpusDecoder.swift
@@ -18,14 +18,8 @@ class LibOpusDecoder {
 
     /// Write some encoded data to the decoder.
     /// - Parameter data: Pointer to some encoded opus data.
-    func write(data: UnsafeRawBufferPointer) throws -> AVAudioPCMBuffer {
-        // Create buffer for the decoded data.
-        let decoded: AVAudioPCMBuffer = .init(pcmFormat: decodedFormat,
-                                              frameCapacity: .opusMax)!
-        try data.withMemoryRebound(to: UInt8.self) {
-            try decoder.decode($0, to: decoded)
-        }
-        return decoded
+    func write(data: Data) throws -> AVAudioPCMBuffer {
+        return try decoder.decode(data)
     }
 
     func plc(frames: AVAudioFrameCount) throws -> AVAudioPCMBuffer {

--- a/Decimus/Lib/QMedia/QDelegatesObjC.h
+++ b/Decimus/Lib/QMedia/QDelegatesObjC.h
@@ -12,7 +12,7 @@
 @protocol QSubscriptionDelegateObjC
 - (int) prepare: (NSString*) sourceID label: (NSString*) label qualityProfile: (NSString*) qualityProfile reliable: (bool*) reliable;
 - (int) update: (NSString*) sourceID label: (NSString*) label qualityProfile: (NSString*) qualityProfile;
-- (int) subscribedObject: (NSData*) data groupId: (UInt32) groupId objectId: (UInt16) objectId;
+- (int) subscribedObject: (const void*) data length: (size_t) length groupId: (UInt32) groupId objectId: (UInt16) objectId;
 @end
 
 @protocol QPublicationDelegateObjC

--- a/Decimus/Lib/QMedia/QMediaDelegates.mm
+++ b/Decimus/Lib/QMedia/QMediaDelegates.mm
@@ -39,8 +39,7 @@ quicr::Namespace QMediaSubscriptionDelegate::getNamespace() {
 }*/
 
 int QMediaSubscriptionDelegate::subscribedObject(quicr::bytes&& data, std::uint32_t group, std::uint16_t object) {
-    NSData * nsdata= [NSData dataWithBytes:data.data() length:data.size()];
-    return [delegate subscribedObject:nsdata groupId:group objectId:object];
+    return [delegate subscribedObject:data.data() length:data.size() groupId:group objectId:object];
 }
 
 

--- a/Decimus/Models/Subscription.swift
+++ b/Decimus/Models/Subscription.swift
@@ -14,5 +14,5 @@ protocol Subscription: QSubscriptionDelegateObjC {
 
     func prepare(_ sourceID: SourceIDType!, label: String!, qualityProfile: String!, reliable: UnsafeMutablePointer<Bool>!) -> Int32
     func update(_ sourceId: String!, label: String!, qualityProfile: String!) -> Int32
-    func subscribedObject(_ data: Data!, groupId: UInt32, objectId: UInt16) -> Int32
+    func subscribedObject(_ data: UnsafeRawPointer!, length: Int, groupId: UInt32, objectId: UInt16) -> Int32
 }

--- a/Decimus/Subscriptions/H264Subscription.swift
+++ b/Decimus/Subscriptions/H264Subscription.swift
@@ -123,7 +123,7 @@ class H264Subscription: Subscription {
         return SubscriptionError.NoDecoder.rawValue
     }
 
-    func subscribedObject(_ data: Data!, groupId: UInt32, objectId: UInt16) -> Int32 {
+    func subscribedObject(_ data: UnsafeRawPointer!, length: Int, groupId: UInt32, objectId: UInt16) -> Int32 {
         // Metrics.
         if let measurement = self.measurement {
             let now: Date? = self.granularMetrics ? .now : nil
@@ -144,7 +144,7 @@ class H264Subscription: Subscription {
                     await measurement.receiveDelta(delta: delta, timestamp: now)
                 }
                 await measurement.receivedFrame(timestamp: now)
-                await measurement.receivedBytes(received: data.count, timestamp: now)
+                await measurement.receivedBytes(received: length, timestamp: now)
             }
         }
 
@@ -154,10 +154,12 @@ class H264Subscription: Subscription {
             participant.lastUpdated = .now()
         }
 
-        let videoFrame: VideoFrame = .init(groupId: groupId, objectId: objectId, data: data)
         if let jitterBuffer = self.jitterBuffer {
+            let videoFrame: VideoFrame = .init(groupId: groupId, objectId: objectId, data: .init(bytes: data, count: length))
             _ = jitterBuffer.write(videoFrame: videoFrame)
         } else {
+            let zeroCopy: Data = .init(bytesNoCopy: .init(mutating: data), count: length, deallocator: .none)
+            let videoFrame: VideoFrame = .init(groupId: groupId, objectId: objectId, data: zeroCopy)
             decode(frame: videoFrame)
         }
         return SubscriptionError.None.rawValue


### PR DESCRIPTION
Seems like calling back the pointer itself actually matches the "interface" to QMedia better, but the real benefit is making the copy/zero-copy semantics/decision really clear in the Swift subscription callback. Previously, it was not obvious if the ObjC is copying that data (which it is), or who is retaining that NSData, if anyone. This seemed cleaner to me, and then we can use `Data` going forwards everywhere, with the safety it provides. 

Also, if we moved to C++ direct interop, we'd probably be working on the pointer anyway(?).