### PR TITLE
Don't forward SEIs onto the decoder

### DIFF
--- a/Decimus/Codec/H264Utilities.swift
+++ b/Decimus/Codec/H264Utilities.swift
@@ -94,6 +94,7 @@ class H264Utilities {
             // Callback any SEIs.
             if type == .sei {
                 sei(nalu)
+                continue
             }
 
             results.append(try depacketizeNalu(&nalu, timeInfo: timeInfo, format: format!))

--- a/Tests/TestH264Utilities.swift
+++ b/Tests/TestH264Utilities.swift
@@ -69,4 +69,23 @@ final class TestH264Utilities: XCTestCase {
             }
         }
     }
+
+    func testseiCallback() throws {
+        let values: [UInt8] = [
+            0x00,0x00,0x00,0x01,
+            H264Utilities.H264Types.sei.rawValue,2,3,4,5
+        ]
+        let data = Data(values)
+        var copied = data
+        var format: CMFormatDescription? = try .init(metadataFormatType: .h264)
+        var foundSei = false
+        let samples = try H264Utilities.depacketize(&copied,
+                                                timeInfo: .init(),
+                                                format: &format) { sei in
+            XCTAssertEqual(data, sei)
+            foundSei = true
+        }
+        XCTAssert(foundSei)
+        XCTAssertEqual(samples.count, 0)
+    }
 }


### PR DESCRIPTION
It seems as though actually writing SEIs to the decoder causes a decoder error. On a mac, this doesn't seem to be a huge issue, but on an iphone it seems to result in only IDRs being correctly decoded. Added a test to ensure the behavior. 

I am looking into what happens with the layer here (the layer doesn't print a warning, but it's generally quite quiet). 