### PR TITLE
Subscriptions to hold a strong reference to video participants

### DIFF
--- a/Decimus/Subscriptions/H264Subscription.swift
+++ b/Decimus/Subscriptions/H264Subscription.swift
@@ -47,7 +47,7 @@ class H264Subscription: Subscription {
     internal let namespace: QuicrNamespace
 
     private var decoder: H264Decoder?
-    private unowned let participants: VideoParticipants
+    private let participants: VideoParticipants
     private let measurement: _Measurement?
     private var lastGroup: UInt32?
     private var lastObject: UInt16?

--- a/Decimus/Subscriptions/SubscriptionFactory.swift
+++ b/Decimus/Subscriptions/SubscriptionFactory.swift
@@ -61,7 +61,7 @@ class SubscriptionFactory {
                                              CodecConfig,
                                              MetricsSubmitter?) throws -> Subscription?
 
-    private unowned let participants: VideoParticipants
+    private let participants: VideoParticipants
     private let engine: DecimusAudioEngine
     private let config: SubscriptionConfig
     private let granularMetrics: Bool


### PR DESCRIPTION
I've verified this has no negative impact on destruction. Closes #233 