### PR TITLE
Fix hotloop

### DIFF
--- a/Decimus/Subscriptions/VideoSubscription.swift
+++ b/Decimus/Subscriptions/VideoSubscription.swift
@@ -183,6 +183,7 @@ class VideoSubscription: QSubscriptionDelegateObjC {
 
         guard let first = sorted.first else { fatalError() }
 
+        self.lastVideoHandler = first.key
         let sample = first.value
         let width = sample.formatDescription!.dimensions.width
         if let lastQuality = self.lastQuality,


### PR DESCRIPTION
Fixes #318 

There was a hotloop when a video subscription had no frames to query when making a simulreceive decision. This should instead have been either a wait until the next frame estimation time (using the last used handler's timeline) or the lowest frame duration for all profiles if there is no last handler. 