### PR TITLE
Fix always dispatch

### DIFF
--- a/Decimus/ErrorWriter.swift
+++ b/Decimus/ErrorWriter.swift
@@ -55,9 +55,9 @@ class DecimusLogger {
     }
 
     func log(level: LogLevel, _ msg: String, alert: Bool = false) {
-        let now = Date.now
         logger.log(level: OSLogType(level), "\(msg, privacy: .public)")
         guard alert else { return }
+        let now = Date.now
         DispatchQueue.main.async { [weak self] in
             guard let self = self else { return }
             Self.shared.alerts.append(.init(date: now, category: self.category, level: level, message: msg))
@@ -65,12 +65,12 @@ class DecimusLogger {
     }
 
     func log(_ msg: String, alert: Bool = false) {
-        let now = Date.now
         logger.log("\(msg)")
-
         #if DEBUG
+        guard alert else { return }
+        let now = Date.now
         DispatchQueue.main.async { [weak self] in
-            guard let self = self, alert else { return }
+            guard let self = self else { return }
             Self.shared.alerts.append(.init(date: now, category: self.category, level: .info, message: msg))
         }
         #endif


### PR DESCRIPTION
We were always dispatching to the main thread, but the vast majority of the time we don't need to do when not alerting: the alert guard should be pre-dispatch. We can also save querying the date time until we know we need it. 