### PR TITLE
Ensure measurements registration is safe

### DIFF
--- a/Decimus/Publications/H264Publication.swift
+++ b/Decimus/Publications/H264Publication.swift
@@ -37,11 +37,7 @@ class H264Publication: NSObject, AVCaptureDevicePublication, FrameListener {
         self.codec = config
         self.metricsSubmitter = metricsSubmitter
         if let metricsSubmitter = metricsSubmitter {
-            let measurement = H264Publication._Measurement(namespace: namespace)
-            self.measurement = measurement
-            Task(priority: .utility) {
-                await metricsSubmitter.register(measurement: measurement)
-            }
+            self.measurement = .init(namespace: namespace)
         } else {
             self.measurement = nil
         }
@@ -82,6 +78,13 @@ class H264Publication: NSObject, AVCaptureDevicePublication, FrameListener {
         super.init()
 
         Self.logger.info("Registered H264 publication for source \(sourceID)")
+
+        if let metricsSubmitter = self.metricsSubmitter,
+           let measurement = self.measurement {
+            Task(priority: .utility) {
+                await metricsSubmitter.register(measurement: measurement)
+            }
+        }
     }
 
     deinit {

--- a/Decimus/Subscriptions/OpusSubscription.swift
+++ b/Decimus/Subscriptions/OpusSubscription.swift
@@ -34,11 +34,7 @@ class OpusSubscription: QSubscriptionDelegateObjC {
         self.engine = engine
         self.metricsSubmitter = submitter
         if let submitter = submitter {
-            let measurement = OpusSubscription._Measurement(namespace: self.sourceId)
-            self.measurement = measurement
-            Task(priority: .utility) {
-                await submitter.register(measurement: measurement)
-            }
+            self.measurement = .init(namespace: self.sourceId)
         } else {
             self.measurement = nil
         }
@@ -70,6 +66,13 @@ class OpusSubscription: QSubscriptionDelegateObjC {
                     }
                 }
                 try? await Task.sleep(for: .seconds(self.cleanupTimer), tolerance: .seconds(self.cleanupTimer), clock: .continuous)
+            }
+        }
+
+        if let metricsSubmitter = self.metricsSubmitter,
+           let measurement = self.measurement {
+            Task(priority: .utility) {
+                await metricsSubmitter.register(measurement: measurement)
             }
         }
 

--- a/Decimus/Views/InCallView.swift
+++ b/Decimus/Views/InCallView.swift
@@ -233,9 +233,6 @@ extension InCallView {
                 let influx = InfluxMetricsSubmitter(config: influxConfig.value, tags: tags)
                 submitter = influx
                 self.measurement = .init()
-                Task(priority: .utility) {
-                    await submitter?.register(measurement: self.measurement!)
-                }
                 if influxConfig.value.realtime {
                     // Application metrics timer.
                     self.appMetricTimer = .init(priority: .utility) { [weak self] in
@@ -267,6 +264,13 @@ extension InCallView {
                                             granularMetrics: influxConfig.value.granular)
             } catch {
                 Self.logger.error("CallController failed: \(error.localizedDescription)", alert: true)
+            }
+
+            if let submitter = self.submitter,
+               let measurement = self.measurement {
+                Task(priority: .utility) {
+                    await submitter.register(measurement: measurement)
+                }
             }
         }
 


### PR DESCRIPTION
Registrations were typically undone in `deinit`, but if the constructor throws an exception after the registration, it would never be unregistered (will still be cleaned up by a weak check on submit though).

This moves registrations until after any throwing calls in the constructor. 