### PR TITLE
Fix qlog path on iOS

### DIFF
--- a/Decimus/CallController.swift
+++ b/Decimus/CallController.swift
@@ -51,10 +51,13 @@ class CallController: QControllerGWObjC<PublisherDelegate, SubscriberDelegate> {
     }
 
     func connect(config: CallConfig) async throws {
-        let url = try FileManager.default.url(for: FileManager.SearchPathDirectory.downloadsDirectory,
-                                              in: FileManager.SearchPathDomainMask.userDomainMask,
-                                              appropriateFor: nil, create: true)
-        try url.path.withCString { downloadDir in
+        let url: URL
+        #if targetEnvironment(macCatalyst)
+        url = .downloadsDirectory
+        #else
+        url = .documentsDirectory
+        #endif
+        try url.path.withCString { dir in
             let transportConfig: TransportConfig = .init(tls_cert_filename: nil,
                                                          tls_key_filename: nil,
                                                          time_queue_init_queue_size: 1000,
@@ -69,7 +72,7 @@ class CallController: QControllerGWObjC<PublisherDelegate, SubscriberDelegate> {
                                                          idle_timeout_ms: 15000,
                                                          use_reset_wait_strategy: self.config.useResetWaitCC,
                                                          use_bbr: self.config.useBBR,
-                                                         quic_qlog_path: self.config.enableQlog ? downloadDir : nil)
+                                                         quic_qlog_path: self.config.enableQlog ? dir : nil)
             let error = super.connect(config.email,
                                       relay: config.address,
                                       port: config.port,

--- a/Decimus/Info.plist
+++ b/Decimus/Info.plist
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>UISupportsDocumentBrowser</key>
+	<true/>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>NSAppTransportSecurity</key>


### PR DESCRIPTION
`downloads` path on iOS is a weird sandboxed directory that's not even allowed to be written to it turns out - suggested to use `documents` instead.

On the other hand, sandboxing means that `documents` on Mac is a weird folder - it's not `~/Documents`. So picked user wide `~/Downloads` on Mac, sandboxed app `documents` folder on iOS/other platforms, and enabled `UISupportsDocumentBrowser` so you can navigate to your saved qlog file using the files app on iOS if you need to. 