### PR TITLE
Use lossy compressed format

### DIFF
--- a/Decimus/CaptureManager.swift
+++ b/Decimus/CaptureManager.swift
@@ -203,14 +203,16 @@ class CaptureManager: NSObject, AVCaptureVideoDataOutputSampleBufferDelegate {
         }
 
         // Prepare IO.
+        // TODO: Theoretically all of these may need to be reconfigured on a device format change.
         let input: AVCaptureDeviceInput = try .init(device: device)
         let output: AVCaptureVideoDataOutput = .init()
-        let lossless420 = kCVPixelFormatType_Lossless_420YpCbCr8BiPlanarVideoRange
+        let lossless420 = kCVPixelFormatType_Lossy_420YpCbCr8BiPlanarFullRange
         output.videoSettings = [:]
         if output.availableVideoPixelFormatTypes.contains(where: {
             $0 == lossless420
         }) {
             output.videoSettings[kCVPixelBufferPixelFormatTypeKey as String] = lossless420
+            Self.logger.debug("[\(device.localizedName)] Using lossy compressed format")
         }
         output.videoSettings[AVVideoColorPropertiesKey] = [
             AVVideoColorPrimariesKey: AVVideoColorPrimaries_ITU_R_709_2,


### PR DESCRIPTION
Change compressed pixel buffer format to `kCVPixelFormatType_Lossy_420YpCbCr8BiPlanarFullRange`. Our format is in full range so should match, and from lossless to lossy per [TN3121](https://developer.apple.com/documentation/technotes/tn3121-selecting-a-pixel-format-for-an-avcapturevideodataoutput):

> In a scenario where your app can utilize a compressed pixel format, always request the lossy variation as the output pixel format if it is available, which will provide additional memory footprint savings. There is no difference in image quality between the lossy, lossless, and uncompressed pixel buffers that you receive from AVCapture. This is because AVCapture internally uses lossy formats on devices that support them. These lossy formats are implemented such that, for most images, the compression is lossless, while the few remaining images are visually lossless.
