### PR TITLE
Better number validation

### DIFF
--- a/Decimus.xcodeproj/project.pbxproj
+++ b/Decimus.xcodeproj/project.pbxproj
@@ -79,6 +79,7 @@
 		9BC53C9E2BFE0AA000BB39C6 /* VarianceCalculator+Measurement.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9BC53C9D2BFE0AA000BB39C6 /* VarianceCalculator+Measurement.swift */; };
 		9BC53CA02BFE151700BB39C6 /* TestVarianceCalculator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9BC53C9F2BFE151700BB39C6 /* TestVarianceCalculator.swift */; };
 		9BC53E0B2B84E0150056C154 /* TestApplicationSEIs.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9BC53E0A2B84E0150056C154 /* TestApplicationSEIs.swift */; };
+		9BCA87032C3423F500DA4F41 /* NumberView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9BCA87022C3423F500DA4F41 /* NumberView.swift */; };
 		9BD96EFD2AC2DAA200EC794C /* VideoJitterBufferSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9BD96EFC2AC2DAA200EC794C /* VideoJitterBufferSettingsView.swift */; };
 		9BDD5B13299697DE00C01D54 /* DequeModule in Frameworks */ = {isa = PBXBuildFile; productRef = 9BDD5B12299697DE00C01D54 /* DequeModule */; };
 		9BDD5B182996A86500C01D54 /* LibOpusDecoder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9BDD5B172996A86500C01D54 /* LibOpusDecoder.swift */; };
@@ -248,6 +249,7 @@
 		9BC53C9D2BFE0AA000BB39C6 /* VarianceCalculator+Measurement.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "VarianceCalculator+Measurement.swift"; sourceTree = "<group>"; };
 		9BC53C9F2BFE151700BB39C6 /* TestVarianceCalculator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestVarianceCalculator.swift; sourceTree = "<group>"; };
 		9BC53E0A2B84E0150056C154 /* TestApplicationSEIs.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestApplicationSEIs.swift; sourceTree = "<group>"; };
+		9BCA87022C3423F500DA4F41 /* NumberView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NumberView.swift; sourceTree = "<group>"; };
 		9BCC0E7F2AB0713000BA97F6 /* TransportConfig.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = TransportConfig.h; sourceTree = "<group>"; };
 		9BD96EFC2AC2DAA200EC794C /* VideoJitterBufferSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VideoJitterBufferSettingsView.swift; sourceTree = "<group>"; };
 		9BDD5B172996A86500C01D54 /* LibOpusDecoder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LibOpusDecoder.swift; sourceTree = "<group>"; };
@@ -534,6 +536,7 @@
 				9BA27FF7297DCF3C007013B2 /* CallSetupView.swift */,
 				FFFF72D62A27D47D00D4D5EE /* ErrorView.swift */,
 				18EC340C2A69CFD6004FE2EE /* VideoView.swift */,
+				9BCA87022C3423F500DA4F41 /* NumberView.swift */,
 			);
 			path = Views;
 			sourceTree = "<group>";
@@ -914,6 +917,7 @@
 				D78619472A28FC9D00EC0556 /* QControllerGW.mm in Sources */,
 				FF3334002AA77D8B00DDE4AD /* ManifestTypes.swift in Sources */,
 				FF6D6D752A01CCAE00B535DA /* ManifestController.swift in Sources */,
+				9BCA87032C3423F500DA4F41 /* NumberView.swift in Sources */,
 				9B131E332B7E4A1C00B29D77 /* ApplicationHEVCSEIs.swift in Sources */,
 				9B0C4E1C2A94BA5D00F6A644 /* WrappedOptional.swift in Sources */,
 				FF3B952C2A60C1EF00CE463F /* QJitterBuffer.mm in Sources */,

--- a/Decimus/Views/NumberView.swift
+++ b/Decimus/Views/NumberView.swift
@@ -1,0 +1,92 @@
+import Foundation
+import SwiftUI
+
+/// A view that allows textual entry of a typed integer with UI errors
+/// on overflow / invalid characters, updating a provided Binding
+/// if valid.
+struct NumberView<T: FixedWidthInteger>: View {
+    @Binding var value: T
+    let formatStyle: IntegerFormatStyle<T>
+    let name: String
+    @State private var text: String = ""
+    @State private var errorText: String?
+
+    var body: some View {
+        VStack {
+            TextField(self.name, text: self.$text)
+                .keyboardType(.numberPad)
+                .onChange(of: self.text) {
+                    do {
+                        switch try validate(self.text) {
+                        case .empty:
+                            self.errorText = nil
+                        case .nan:
+                            self.errorText = "\(self.name) must be a number"
+                        case .tooLarge:
+                            self.errorText = "\(self.name) is too large"
+                        case .valid(let parsed):
+                            self.value = parsed
+                            self.errorText = nil
+                        }
+                    } catch {
+                        self.errorText = error.localizedDescription
+                    }
+                }
+            if let error = self.errorText {
+                HStack {
+                    Text(error)
+                        .foregroundStyle(.red)
+                        .font(.footnote)
+                    Spacer()
+                }
+            }
+        }
+        .onAppear {
+            self.text = self.value.formatted(self.formatStyle)
+        }
+        .onChange(of: self.value) {
+            self.text = self.value.formatted(self.formatStyle)
+        }
+    }
+
+    enum ValidationResult {
+        case empty
+        case nan
+        case tooLarge
+        case valid(T)
+    }
+
+    private func validate(_ value: String) throws -> ValidationResult {
+        // Need something.
+        guard !value.isEmpty else {
+            return .empty
+        }
+        // Should be all numbers.
+        guard value.allSatisfy({ $0.isNumber }) else {
+            return .nan
+        }
+
+        // Should be <= UInt16 max value.
+        let max = String(T.max)
+        guard value.count <= max.count else {
+            return .tooLarge
+        }
+
+        // Equals needs digit by digit comparison.
+        if value.count == max.count {
+            for (value, max) in zip(value, max) {
+                guard value <= max else { return .tooLarge }
+            }
+        }
+
+        // Valid!
+        let parsed = try T(value, format: self.formatStyle)
+        return .valid(parsed)
+    }
+}
+
+#Preview {
+    NumberView<UInt8>(value: .constant(1),
+                      formatStyle: .number,
+                      name: "Test")
+}

--- a/Decimus/Views/Settings/InfluxSettingsView.swift
+++ b/Decimus/Views/Settings/InfluxSettingsView.swift
@@ -25,10 +25,9 @@ struct InfluxSettingsView: View {
                 }
 
                 LabeledContent("Interval (s)") {
-                    TextField(
-                        "Interval (s)",
-                        value: $influxConfig.value.intervalSecs,
-                        format: .number)
+                    NumberView(value: $influxConfig.value.intervalSecs,
+                               formatStyle: IntegerFormatStyle<Int>.number.grouping(.never),
+                               name: "Interval (s)")
                 }
 
                 LabeledContent("URL") {

--- a/Decimus/Views/Settings/RelaySettingsView.swift
+++ b/Decimus/Views/Settings/RelaySettingsView.swift
@@ -21,16 +21,15 @@ struct RelaySettingsView: View {
                         }
                     }
                     .pickerStyle(.segmented)
-                    .onChange(of: relayConfig.value.connectionProtocol) { newValue in
+                    .onChange(of: relayConfig.value.connectionProtocol) { _, newValue in
                         relayConfig.value.port = defaultProtocolPorts[newValue] ?? relayConfig.value.port
                     }
                 }
 
                 LabeledContent("Port") {
-                    TextField("relay_port",
-                              value: $relayConfig.value.port,
-                              format: .number.grouping(.never))
-                        .keyboardType(.numberPad)
+                    NumberView(value: self.$relayConfig.value.port,
+                               formatStyle: IntegerFormatStyle<UInt16>.number.grouping(.never),
+                               name: "Port")
                 }
             }
             .formStyle(.columns)

--- a/Decimus/Views/Settings/SubscriptionSettingsView.swift
+++ b/Decimus/Views/Settings/SubscriptionSettingsView.swift
@@ -116,10 +116,9 @@ struct SubscriptionSettingsView: View {
                 }
 
                 LabeledContent("Quality miss threshold (frames)") {
-                    TextField(
-                        "Quality miss threshold (frames)",
-                        value: $subscriptionConfig.value.qualityMissThreshold,
-                        format: .number)
+                    NumberView(value: self.$subscriptionConfig.value.qualityMissThreshold,
+                               formatStyle: IntegerFormatStyle<Int>.number.grouping(.never),
+                               name: "Threshold")
                 }
 
                 HStack {
@@ -128,10 +127,9 @@ struct SubscriptionSettingsView: View {
                 }
 
                 LabeledContent("Pause miss threshold (frames)") {
-                    TextField(
-                        "Pause miss threshold (frames)",
-                        value: $subscriptionConfig.value.pauseMissThreshold,
-                        format: .number)
+                    NumberView(value: self.$subscriptionConfig.value.pauseMissThreshold,
+                               formatStyle: IntegerFormatStyle<Int>.number.grouping(.never),
+                               name: "Threshold")
                 }
             }
             .formStyle(.columns)

--- a/Decimus/Views/Settings/TransportConfigSettings.swift
+++ b/Decimus/Views/Settings/TransportConfigSettings.swift
@@ -13,7 +13,7 @@ struct TransportConfigSettings: View {
     private let maxWindowKiB = 4096
 
     var body: some View {
-#if !os(tvOS)
+        #if !os(tvOS)
         VStack {
             HStack {
                 Stepper {
@@ -29,7 +29,7 @@ struct TransportConfigSettings: View {
                 }
             }
         }
-#endif
+        #endif
         HStack {
             Text("Use Reset and Wait")
             Toggle(isOn: self.$useResetWaitCC) {}
@@ -39,13 +39,19 @@ struct TransportConfigSettings: View {
             Toggle(isOn: self.$useBBR) {}
         }
         LabeledContent("Time Queue RX Size") {
-            TextField("", value: self.$timeQueueTTL, format: .number)
+            NumberView(value: self.$timeQueueTTL,
+                       formatStyle: IntegerFormatStyle<Int>.number.grouping(.never),
+                       name: "Size")
         }
         LabeledContent("Chunk Size") {
-            TextField("", value: self.$chunkSize, format: .number)
+            NumberView(value: self.$chunkSize,
+                       formatStyle: IntegerFormatStyle<UInt32>.number.grouping(.never),
+                       name: "Size")
         }
         LabeledContent("Limit Bypass Priority >= value") {
-            TextField("", value: self.$quicPriorityLimit, format: .number)
+            NumberView(value: self.$quicPriorityLimit,
+                       formatStyle: IntegerFormatStyle<UInt8>.number.grouping(.never),
+                       name: "Priority")
         }
         HStack {
             Text("Capture QUICR logs")


### PR DESCRIPTION
Resolves a crash when passing a number that exceeds the bit count of the target type. Swift considers this a logic error, and so asserts on parsing a number from a string that exceeds the bits of the target type, rather than throwing on the parse. 