### PR TITLE
Move to SwiftLintPlugins version of plugin

### DIFF
--- a/Decimus.xcodeproj/project.pbxproj
+++ b/Decimus.xcodeproj/project.pbxproj
@@ -725,7 +725,7 @@
 			buildRules = (
 			);
 			dependencies = (
-				9BF28F262BE02C1400658353 /* PBXTargetDependency */,
+				9B81EEBF2C6A5796003690F9 /* PBXTargetDependency */,
 			);
 			name = Decimus;
 			packageProductDependencies = (
@@ -771,13 +771,13 @@
 			);
 			mainGroup = 9BA27FB9297D7270007013B2;
 			packageReferences = (
-				9B165A1F298807A40017079F /* XCRemoteSwiftPackageReference "SwiftLint" */,
 				9BDD5B11299697DE00C01D54 /* XCRemoteSwiftPackageReference "swift-collections" */,
 				18C89A382A13D1E4005B333B /* XCRemoteSwiftPackageReference "influxdb-client-swift" */,
 				FFA0E84E2A6F25A20027603B /* XCRemoteSwiftPackageReference "WrappingHStack" */,
 				188ABB542A792E9C00B31A6E /* XCRemoteSwiftPackageReference "swift-opus" */,
 				18BF45762B0E0F3D006E8E24 /* XCRemoteSwiftPackageReference "TPCircularBuffer" */,
 				9B8B6F662B9B01F700FBB0D1 /* XCRemoteSwiftPackageReference "swift-atomics" */,
+				9B81EEBD2C6A578C003690F9 /* XCRemoteSwiftPackageReference "SwiftLintPlugins" */,
 			);
 			productRefGroup = 9BA27FC3297D7270007013B2 /* Products */;
 			projectDirPath = "";
@@ -980,14 +980,14 @@
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
+		9B81EEBF2C6A5796003690F9 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			productRef = 9B81EEBE2C6A5796003690F9 /* SwiftLintBuildToolPlugin */;
+		};
 		9B85952029F04521008C813C /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			target = 9BA27FC1297D7270007013B2 /* Decimus */;
 			targetProxy = 9B85951F29F04521008C813C /* PBXContainerItemProxy */;
-		};
-		9BF28F262BE02C1400658353 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			productRef = 9BF28F252BE02C1400658353 /* SwiftLintPlugin */;
 		};
 /* End PBXTargetDependency section */
 
@@ -1378,12 +1378,12 @@
 				minimumVersion = 1.0.0;
 			};
 		};
-		9B165A1F298807A40017079F /* XCRemoteSwiftPackageReference "SwiftLint" */ = {
+		9B81EEBD2C6A578C003690F9 /* XCRemoteSwiftPackageReference "SwiftLintPlugins" */ = {
 			isa = XCRemoteSwiftPackageReference;
-			repositoryURL = "https://github.com/evfemist/SwiftLint";
+			repositoryURL = "https://github.com/SimplyDanny/SwiftLintPlugins";
 			requirement = {
-				branch = main;
-				kind = branch;
+				kind = upToNextMajorVersion;
+				minimumVersion = 0.56.1;
 			};
 		};
 		9B8B6F662B9B01F700FBB0D1 /* XCRemoteSwiftPackageReference "swift-atomics" */ = {
@@ -1433,6 +1433,11 @@
 			package = 9BDD5B11299697DE00C01D54 /* XCRemoteSwiftPackageReference "swift-collections" */;
 			productName = OrderedCollections;
 		};
+		9B81EEBE2C6A5796003690F9 /* SwiftLintBuildToolPlugin */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 9B81EEBD2C6A578C003690F9 /* XCRemoteSwiftPackageReference "SwiftLintPlugins" */;
+			productName = "plugin:SwiftLintBuildToolPlugin";
+		};
 		9B8B6F672B9B01F700FBB0D1 /* Atomics */ = {
 			isa = XCSwiftPackageProductDependency;
 			package = 9B8B6F662B9B01F700FBB0D1 /* XCRemoteSwiftPackageReference "swift-atomics" */;
@@ -1442,11 +1447,6 @@
 			isa = XCSwiftPackageProductDependency;
 			package = 9BDD5B11299697DE00C01D54 /* XCRemoteSwiftPackageReference "swift-collections" */;
 			productName = DequeModule;
-		};
-		9BF28F252BE02C1400658353 /* SwiftLintPlugin */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = 9B165A1F298807A40017079F /* XCRemoteSwiftPackageReference "SwiftLint" */;
-			productName = "plugin:SwiftLintPlugin";
 		};
 		FFA0E84F2A6F25A20027603B /* WrappingHStack */ = {
 			isa = XCSwiftPackageProductDependency;

--- a/Decimus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Decimus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,15 +1,6 @@
 {
-  "originHash" : "e1eb857a332d01b020e9001a1d1aa6b4b44873d2661ffcd09e61021692162d4b",
+  "originHash" : "0e18a282738bac556786f777d0cc9d699b0c17faaa02a5c43533f19fbb9d4c90",
   "pins" : [
-    {
-      "identity" : "collectionconcurrencykit",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/JohnSundell/CollectionConcurrencyKit.git",
-      "state" : {
-        "revision" : "b4f23e24b5a1bff301efc5e70871083ca029ff95",
-        "version" : "0.2.0"
-      }
-    },
     {
       "identity" : "csv.swift",
       "kind" : "remoteSourceControl",
@@ -35,24 +26,6 @@
       "state" : {
         "revision" : "019d6967ed44ffad93e7b06f0700c11e22f921f8",
         "version" : "1.6.0"
-      }
-    },
-    {
-      "identity" : "sourcekitten",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/jpsim/SourceKitten.git",
-      "state" : {
-        "revision" : "fc12c0f182c5cf80781dd933b17a82eb98bd7c61",
-        "version" : "0.33.1"
-      }
-    },
-    {
-      "identity" : "swift-argument-parser",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-argument-parser.git",
-      "state" : {
-        "revision" : "4ad606ba5d7673ea60679a61ff867cc1ff8c8e86",
-        "version" : "1.2.1"
       }
     },
     {
@@ -92,39 +65,12 @@
       }
     },
     {
-      "identity" : "swift-syntax",
+      "identity" : "swiftlintplugins",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-syntax.git",
+      "location" : "https://github.com/SimplyDanny/SwiftLintPlugins",
       "state" : {
-        "revision" : "edd2d0cdb988ac45e2515e0dd0624e4a6de54a94",
-        "version" : "0.50800.0-SNAPSHOT-2022-12-29-a"
-      }
-    },
-    {
-      "identity" : "swiftlint",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/evfemist/SwiftLint",
-      "state" : {
-        "branch" : "main",
-        "revision" : "a780f2e563d7402f078951c2a0fae0a208548196"
-      }
-    },
-    {
-      "identity" : "swiftytexttable",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/scottrhoyt/SwiftyTextTable.git",
-      "state" : {
-        "revision" : "c6df6cf533d120716bff38f8ff9885e1ce2a4ac3",
-        "version" : "0.9.0"
-      }
-    },
-    {
-      "identity" : "swxmlhash",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/drmohundro/SWXMLHash.git",
-      "state" : {
-        "revision" : "4d0f62f561458cbe1f732171e625f03195151b60",
-        "version" : "7.0.1"
+        "revision" : "9ad9487c2448b3f1265ea2cc8af246b9cae6878d",
+        "version" : "0.56.1"
       }
     },
     {
@@ -143,15 +89,6 @@
       "state" : {
         "revision" : "2638bc5258607e8a32f2e5675d075896c2401678",
         "version" : "0.1.3"
-      }
-    },
-    {
-      "identity" : "yams",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/jpsim/Yams.git",
-      "state" : {
-        "revision" : "c7facc5ccb8c5a4577ea8c491aa875762cdee57a",
-        "version" : "5.0.3"
       }
     }
   ],


### PR DESCRIPTION
Migrate to pre-bundled SwiftLint plugin to avoid collision with other packages bundling SwiftLint. 