### PR TITLE
Append MinimumOSVersion plist entry

### DIFF
--- a/dependencies/build-qmedia-framework.py
+++ b/dependencies/build-qmedia-framework.py
@@ -12,7 +12,7 @@ import argparse
 import shutil
 
 build_type = "RelWithDebInfo"
-generator = "Ninja"
+generator = "Unix Makefiles"
 
 class Platform:
     def __init__(self, type, cmake_platform, build_folder):


### PR DESCRIPTION
Patch in the missing plist entry for iOS and tvOS App Store validation. I still do not fully understand exactly why this used to be fine when qmedia did NOT do this, and also there doesn't seem to be a good way to get CMake to correctly place this in for us, despite a significant amount of attempts. But patching it directly is straightforward, and works. Potential for mismatch, but App Store validation will catch that for us in the worst case. 