### PR TITLE
Add alteration APIs for active publications & subscriptions

### DIFF
--- a/Decimus/CallController.swift
+++ b/Decimus/CallController.swift
@@ -106,26 +106,6 @@ class MoqCallController: QClientCallbacks {
         }
     }
 
-    // TODO: Remove this function.
-    /// Inject a manifest into the controller.
-    /// This causes the creation of the corresponding publications and subscriptions and media objects.
-    /// This MUST be called after connecting.
-    /// - Parameter manifest: The manifest to use.
-    /// - Throws: ``MoqCallControllerError/notConnected`` if not yet connected.
-    func setManifest(_ manifest: Manifest, publicationFactory: PublicationFactory, subscriptionFactory: SubscriptionFactory) throws {
-        guard self.connected else { throw MoqCallControllerError.notConnected }
-
-        // Create subscriptions.
-        for manifestSubscription in manifest.subscriptions {
-            try self.subscribeToSet(details: manifestSubscription, factory: subscriptionFactory)
-        }
-
-        // Create publications.
-        for publication in manifest.publications {
-            try self.publish(details: publication, factory: publicationFactory)
-        }
-    }
-
     /// Disconnect from the relay.
     /// - Throws: ``MoqCallControllerError/connectionFailure(_:)`` with unexpected status.
     func disconnect() throws {

--- a/Decimus/CallController.swift
+++ b/Decimus/CallController.swift
@@ -147,6 +147,10 @@ class MoqCallController: QClientCallbacks {
 
     // MARK: Pub/Sub Modification APIs.
 
+    public func getPublications() -> [FullTrackName] {
+        Array(self.publications.keys)
+    }
+
     /// Setup a publication for a track.
     /// - Parameter details: The details for the publication from the manifest.
     /// - Parameter factory: Factory to create publication objects.
@@ -169,6 +173,10 @@ class MoqCallController: QClientCallbacks {
             throw MoqCallControllerError.publicationNotFound
         }
         self.client.unpublishTrack(withHandler: publication)
+    }
+
+    public func getSubscriptionSets() -> [SourceIDType] {
+        Array(self.subscriptions.keys)
     }
 
     /// Subscribe to a logically related set of subscriptions.

--- a/Decimus/CallController.swift
+++ b/Decimus/CallController.swift
@@ -13,6 +13,8 @@ enum MoqCallControllerError: Error {
     case notConnected
     /// No server message was received.
     case missingSetup
+    /// The specified publication was not found.
+    case publicationNotFound
 }
 
 /// Represents a client-facing collection of logically related subscriptions,
@@ -22,7 +24,7 @@ enum MoqCallControllerError: Error {
 protocol SubscriptionSet {
     /// Get the subscribe track handlers for this subscription set.
     /// - Returns: The (one or more) subscribe track handlers for this subscription.
-    func getHandlers() -> [QSubscribeTrackHandlerObjC]
+    func getHandlers() -> [FullTrackName: QSubscribeTrackHandlerObjC]
 }
 
 /// Swift mapping for underlying client configuration.
@@ -51,25 +53,29 @@ class MoqCallController: QClientCallbacks {
     private let captureManager: CaptureManager
 
     // State.
-    private let client: QClientObjC
-    private let config: ClientConfig
+    private let client: MoqClient
+    private let endpointUri: String
     private var connectionContinuation: CheckedContinuation<Void, Error>?
     private var publications: [FullTrackName: QPublishTrackHandlerObjC] = [:]
     private var subscriptions: [SourceIDType: SubscriptionSet] = [:]
     private var connected = false
     private let callEnded: () -> Void
-    var serverId: String?
+
+    /// The identifier of the connected server, or nil if not connected.
+    public private(set) var serverId: String?
 
     /// Create a new controller.
     /// - Parameters:
-    ///   - config: Underlying `quicr::Client` config.
+    ///   - endpointUri: A unique identifier for this endpoint.
+    ///   - client: An implementation of a MoQ client.
     ///   - captureManager: Video camera capture manager.
     ///   - subscriptionConfig: Application configuration for subscription creation.
     ///   - engine: Audio capture/playout engine.
     ///   - videoParticipants: Video rendering manager.
     ///   - submitter: Optionally, a submitter through which to submit metrics.
     ///   - granularMetrics: True to enable granular metrics, with a potential performance cost.
-    init(config: ClientConfig,
+    init(endpointUri: String,
+         client: MoqClient,
          captureManager: CaptureManager,
          subscriptionConfig: SubscriptionConfig,
          engine: DecimusAudioEngine,
@@ -77,15 +83,8 @@ class MoqCallController: QClientCallbacks {
          submitter: MetricsSubmitter?,
          granularMetrics: Bool,
          callEnded: @escaping () -> Void) {
-        self.config = config
-        self.client = config.connectUri.withCString { connectUri in
-            config.endpointUri.withCString { endpointId in
-                QClientObjC(config: .init(connectUri: connectUri,
-                                          endpointId: endpointId,
-                                          transportConfig: config.transportConfig,
-                                          metricsSampleMs: config.metricsSampleMs))
-            }
-        }
+        self.endpointUri = endpointUri
+        self.client = client
         self.captureManager = captureManager
         self.subscriptionConfig = subscriptionConfig
         self.engine = engine
@@ -94,7 +93,7 @@ class MoqCallController: QClientCallbacks {
         self.granularMetrics = granularMetrics
         self.callEnded = callEnded
         if let metricsSubmitter = submitter {
-            let measurement = MoqCallController.MoqCallControllerMeasurement(endpointId: config.endpointUri)
+            let measurement = MoqCallController.MoqCallControllerMeasurement(endpointId: endpointUri)
             self.measurement = .init(measurement: measurement, submitter: metricsSubmitter)
         } else {
             self.measurement = nil
@@ -134,51 +133,30 @@ class MoqCallController: QClientCallbacks {
     /// This MUST be called after connecting.
     /// - Parameter manifest: The manifest to use.
     /// - Throws: ``MoqCallControllerError/notConnected`` if not yet connected.
-    func setManifest(_ manifest: Manifest) throws {
+    func setManifest(_ manifest: Manifest, publicationFactory: PublicationFactory, subscriptionFactory: SubscriptionFactory) throws {
+        assert(Thread.isMainThread)
         guard self.connected else { throw MoqCallControllerError.notConnected }
-        guard let serverId = self.serverId else { throw MoqCallControllerError.missingSetup }
 
         // Create subscriptions.
         for manifestSubscription in manifest.subscriptions {
-            let subscription = try self.create(subscription: manifestSubscription,
-                                               endpointId: self.config.endpointUri,
-                                               relayId: serverId)
-            self.subscriptions[manifestSubscription.sourceID] = subscription
-            for handler in subscription.getHandlers() {
-                self.client.subscribeTrack(withHandler: handler)
-            }
+            try self.subscribeToSet(details: manifestSubscription, factory: subscriptionFactory)
         }
 
         // Create publications.
-        // TODO: We probably don't need a factory here. Just handle it internal to the controller.
-        // TODO: If it gets bigger, we can extract.
-        let pubFactory = PublicationFactory(opusWindowSize: self.subscriptionConfig.opusWindowSize,
-                                            reliability: self.subscriptionConfig.mediaReliability,
-                                            engine: self.engine,
-                                            metricsSubmitter: self.metricsSubmitter,
-                                            granularMetrics: self.granularMetrics,
-                                            captureManager: self.captureManager)
         for publication in manifest.publications {
-            let created = try pubFactory.create(publication: publication,
-                                                endpointId: self.config.endpointUri,
-                                                relayId: serverId)
-            for (namespace, handler) in created {
-                self.publications[namespace] = handler
-                self.client.publishTrack(withHandler: handler)
-            }
+            try self.publish(details: publication, factory: publicationFactory)
         }
     }
 
     /// Disconnect from the relay.
     /// - Throws: ``MoqCallControllerError/connectionFailure(_:)`` with unexpected status.
     func disconnect() throws {
+        assert(Thread.isMainThread)
         for publication in self.publications {
-            self.client.unpublishTrack(withHandler: publication.value)
+            try self.unpublish(publication.key)
         }
         for set in self.subscriptions {
-            for subscription in set.value.getHandlers() {
-                self.client.unsubscribeTrack(withHandler: subscription)
-            }
+            try self.unsubscribeToSet(set.key)
         }
         let status = self.client.disconnect()
         guard status == .disconnecting else {
@@ -187,6 +165,61 @@ class MoqCallController: QClientCallbacks {
         self.logger.info("[MoqCallController] Disconnected")
         self.publications.removeAll()
         self.subscriptions.removeAll()
+    }
+
+    // MARK: Pub/Sub Modification APIs.
+
+    /// Setup a publication for a track.
+    /// - Parameter details: The details for the publication from the manifest.
+    /// - Parameter factory: Factory to create publication objects.
+    public func publish(details: ManifestPublication, factory: PublicationFactory) throws {
+        assert(Thread.isMainThread)
+        guard self.connected else { throw MoqCallControllerError.notConnected }
+        let created = try factory.create(publication: details,
+                                         endpointId: self.endpointUri,
+                                         relayId: self.serverId!)
+        for (namespace, handler) in created {
+            self.publications[namespace] = handler
+            self.client.publishTrack(withHandler: handler)
+        }
+    }
+
+    /// Stop publishing to a track.
+    /// - Parameter fullTrackName: The FTN to unpublish.
+    public func unpublish(_ fullTrackName: FullTrackName) throws {
+        assert(Thread.isMainThread)
+        guard self.connected else { throw MoqCallControllerError.notConnected }
+        guard let publication = self.publications.removeValue(forKey: fullTrackName) else {
+            throw MoqCallControllerError.publicationNotFound
+        }
+        self.client.unpublishTrack(withHandler: publication)
+    }
+
+    /// Subscribe to a logically related set of subscriptions.
+    /// - Parameter details: The details of the subscription set.
+    public func subscribeToSet(details: ManifestSubscription, factory: SubscriptionFactory) throws {
+        assert(Thread.isMainThread)
+        guard self.connected else { throw MoqCallControllerError.notConnected }
+        let subscription = try factory.create(subscription: details,
+                                              endpointId: self.endpointUri,
+                                              relayId: self.serverId!)
+        self.subscriptions[details.sourceID] = subscription
+        for handler in subscription.getHandlers() {
+            self.client.subscribeTrack(withHandler: handler.value)
+        }
+    }
+
+    /// Unpublish a subscription set (and all contained track subscriptions).
+    /// - Parameter sourceID: The identifier of the subscription set.
+    public func unsubscribeToSet(_ sourceID: SourceIDType) throws {
+        assert(Thread.isMainThread)
+        guard self.connected else { throw MoqCallControllerError.notConnected }
+        guard let subscription = self.subscriptions.removeValue(forKey: sourceID) else {
+            throw MoqCallControllerError.publicationNotFound
+        }
+        for handler in subscription.getHandlers() {
+            self.client.unsubscribeTrack(withHandler: handler.value)
+        }
     }
 
     // MARK: Callbacks.
@@ -200,6 +233,12 @@ class MoqCallController: QClientCallbacks {
             // TODO: Fix this up.
             guard let connection = self.connectionContinuation else {
                 print("Got ready when we already had ready!?")
+                return
+            }
+            guard self.serverId != nil else {
+                self.logger.error("Missing expected Server Setup on ready")
+                connection.resume(throwing: MoqCallControllerError.missingSetup)
+                self.connectionContinuation = nil
                 return
             }
             self.connectionContinuation = nil
@@ -258,53 +297,6 @@ class MoqCallController: QClientCallbacks {
     /// - Parameter relayId: The identifier of the relay we are connecting to (for metrics/correlation).
     /// - Throws: ``CodecError/unsupportedCodecSet(_:)`` if unsupported media type.
     /// Other errors on failure to create client media subscription handlers.
-    private func create(subscription: ManifestSubscription,
-                        endpointId: String,
-                        relayId: String) throws -> SubscriptionSet {
-        // Supported codec sets.
-        let videoCodecs: Set<CodecType> = [.h264, .hevc]
-        let opusCodecs: Set<CodecType> = [.opus]
-
-        // Resolve profile sets to config.
-        var foundCodecs: [CodecType] = []
-        for profile in subscription.profileSet.profiles {
-            let config = CodecFactory.makeCodecConfig(from: profile.qualityProfile,
-                                                      bitrateType: self.subscriptionConfig.bitrateType)
-            foundCodecs.append(config.codec)
-        }
-        let found = Set(foundCodecs)
-        if found.isSubset(of: videoCodecs) {
-            return try VideoSubscriptionSet(subscription: subscription,
-                                            participants: self.videoParticipants,
-                                            metricsSubmitter: self.metricsSubmitter,
-                                            videoBehaviour: self.subscriptionConfig.videoBehaviour,
-                                            reliable: self.subscriptionConfig.mediaReliability.video.subscription,
-                                            granularMetrics: self.granularMetrics,
-                                            jitterBufferConfig: self.subscriptionConfig.videoJitterBuffer,
-                                            simulreceive: self.subscriptionConfig.simulreceive,
-                                            qualityMissThreshold: self.subscriptionConfig.qualityMissThreshold,
-                                            pauseMissThreshold: self.subscriptionConfig.pauseMissThreshold,
-                                            pauseResume: self.subscriptionConfig.pauseResume,
-                                            endpointId: endpointId,
-                                            relayId: relayId)
-        }
-
-        if found.isSubset(of: opusCodecs) {
-            return try OpusSubscription(subscription: subscription,
-                                        engine: self.engine,
-                                        submitter: self.metricsSubmitter,
-                                        jitterDepth: self.subscriptionConfig.jitterDepthTime,
-                                        jitterMax: self.subscriptionConfig.jitterMaxTime,
-                                        opusWindowSize: self.subscriptionConfig.opusWindowSize,
-                                        reliable: self.subscriptionConfig.mediaReliability.audio.subscription,
-                                        granularMetrics: self.granularMetrics,
-                                        endpointId: endpointId,
-                                        relayId: relayId,
-                                        useNewJitterBuffer: self.subscriptionConfig.useNewJitterBuffer)
-        }
-
-        throw CodecError.unsupportedCodecSet(found)
-    }
 
     /// libquicr's metrics callback.
     /// - Parameter metrics: Object containing all metrics.

--- a/Decimus/Lib/Decimus-Bridging-Header.h
+++ b/Decimus/Lib/Decimus-Bridging-Header.h
@@ -8,6 +8,7 @@
 #import "EncodedBuffer/EncodedFrameBufferAllocator.h"
 #import "Utilities/SwiftInterop.h"
 
+#import "libquicr/QFullTrackName.h"
 #import "libquicr/QPublishTrackHandlerCallbacks.h"
 #import "libquicr/QSubscribeTrackHandlerCallbacks.h"
 #import "libquicr/QCommon.h"

--- a/Decimus/Lib/libquicr/FullTrackName.swift
+++ b/Decimus/Lib/libquicr/FullTrackName.swift
@@ -29,6 +29,18 @@ struct FullTrackName: Hashable {
         self.name = name
     }
 
+    func get() -> QFullTrackName {
+        let ftn = QFullTrackName()
+        ftn.nameSpace = self.namespace
+        ftn.name = self.name
+        return ftn
+    }
+
+    init(_ ftn: QFullTrackName) {
+        self.namespace = ftn.nameSpace
+        self.name = ftn.name
+    }
+
     /// Get the namespace as an ASCII string.
     /// - Returns: ASCII string of namespace.
     /// - Throws: ``FullTrackNameError/parseError`` if ``namespace`` is not ecodable as ASCII.
@@ -47,23 +59,5 @@ struct FullTrackName: Hashable {
             throw FullTrackNameError.parseError
         }
         return name
-    }
-
-    /// Get the underlying ``QFullTrackName`` object corresponding to this ``FullTrackName``.
-    /// This reference MUST NOT be used outside of the scope of the owning ``FullTrackName``.
-    /// - Returns: A ``QFullTrackName`` view into this ``FullTrackName``.
-    func getUnsafe() -> QFullTrackName {
-        return self.namespace.withUnsafeBytes { namespace in
-            let namespacePtr: UnsafePointer<CChar> = namespace.baseAddress!.bindMemory(to: CChar.self,
-                                                                                       capacity: namespace.count)
-            return self.name.withUnsafeBytes { name in
-                let namePtr: UnsafePointer<CChar> = name.baseAddress!.bindMemory(to: CChar.self, capacity: name.count)
-
-                return .init(nameSpace: namespacePtr,
-                             nameSpaceLength: self.namespace.count,
-                             name: namePtr,
-                             nameLength: self.name.count)
-            }
-        }
     }
 }

--- a/Decimus/Lib/libquicr/FullTrackName.swift
+++ b/Decimus/Lib/libquicr/FullTrackName.swift
@@ -8,9 +8,13 @@ enum FullTrackNameError: Error {
 }
 
 /// A MoQ full track name identifies a track within a namespace.
-struct FullTrackName: Hashable {
+class FullTrackName: QFullTrackName, Hashable {
+    static func == (lhs: FullTrackName, rhs: FullTrackName) -> Bool {
+        lhs.nameSpace == rhs.nameSpace && lhs.name == rhs.name
+    }
+
     /// The namespace portion of the full track name.
-    let namespace: Data
+    let nameSpace: Data
     /// The name portion of the full track name.
     let name: Data
 
@@ -22,30 +26,23 @@ struct FullTrackName: Hashable {
         guard let namespace = namespace.data(using: .ascii) else {
             throw FullTrackNameError.parseError
         }
-        self.namespace = namespace
+        self.nameSpace = namespace
         guard let name = name.data(using: .ascii) else {
             throw FullTrackNameError.parseError
         }
         self.name = name
     }
 
-    func get() -> QFullTrackName {
-        let ftn = QFullTrackName()
-        ftn.nameSpace = self.namespace
-        ftn.name = self.name
-        return ftn
-    }
-
-    init(_ ftn: QFullTrackName) {
-        self.namespace = ftn.nameSpace
-        self.name = ftn.name
+    func hash(into hasher: inout Hasher) {
+        hasher.combine(self.name)
+        hasher.combine(self.nameSpace)
     }
 
     /// Get the namespace as an ASCII string.
     /// - Returns: ASCII string of namespace.
     /// - Throws: ``FullTrackNameError/parseError`` if ``namespace`` is not ecodable as ASCII.
     func getNamespace() throws -> String {
-        guard let namespace = String(data: self.namespace, encoding: .ascii) else {
+        guard let namespace = String(data: self.nameSpace, encoding: .ascii) else {
             throw FullTrackNameError.parseError
         }
         return namespace

--- a/Decimus/Lib/libquicr/QClientObjC.h
+++ b/Decimus/Lib/libquicr/QClientObjC.h
@@ -16,37 +16,34 @@
 
 #import <Foundation/Foundation.h>
 
-@interface QClientObjC : NSObject
+typedef struct QClientConfig {
+    const char* _Nonnull connectUri;
+    const char* _Nonnull endpointId;
+    TransportConfig transportConfig;
+    uint64_t metricsSampleMs;
+} QClientConfig;
+
+@protocol MoqClient
+- (QClientStatus)connect;
+- (QClientStatus)disconnect;
+- (void)publishTrackWithHandler:(QPublishTrackHandlerObjC * _Nonnull)handler;
+- (void)unpublishTrackWithHandler:(QPublishTrackHandlerObjC * _Nonnull)handler;
+- (void)publishAnnounce:(NSData * _Nonnull)trackNamespace;
+- (void)publishUnannounce:(NSData * _Nonnull)trackNamespace;
+- (void)subscribeTrackWithHandler:(QSubscribeTrackHandlerObjC * _Nonnull)handler;
+- (void)unsubscribeTrackWithHandler:(QSubscribeTrackHandlerObjC * _Nonnull)handler;
+- (QPublishAnnounceStatus)getAnnounceStatus:(NSData * _Nonnull)trackNamespace;
+- (void)setCallbacks:(id <QClientCallbacks> _Nonnull)callbacks;
+@end
+
+@interface QClientObjC : NSObject<MoqClient>
 {
 #ifdef __cplusplus
    std::unique_ptr<QClient> qClientPtr;
 #endif
 }
 
-typedef struct QClientConfig {
-    const char* connectUri;
-    const char* endpointId;
-    TransportConfig transportConfig;
-    uint64_t metricsSampleMs;
-} QClientConfig;
-
--(id)initWithConfig: (QClientConfig) config;
-
--(QClientStatus)connect;
--(QClientStatus)disconnect;
-
--(void) publishTrackWithHandler: (QPublishTrackHandlerObjC*) handler;
--(void) unpublishTrackWithHandler: (QPublishTrackHandlerObjC*) handler;
-
--(void) publishAnnounce: (NSData*) trackNamespace;
--(void) publishUnannounce: (NSData*) trackNamespace;
-
--(void) subscribeTrackWithHandler: (QSubscribeTrackHandlerObjC*) handler;
--(void) unsubscribeTrackWithHandler: (QSubscribeTrackHandlerObjC*) handler;
-
--(QPublishAnnounceStatus) getAnnounceStatus: (NSData*) trackNamespace;
-
--(void)setCallbacks: (id<QClientCallbacks>) callbacks;
+- (nonnull instancetype)initWithConfig:(QClientConfig)config;
 
 @end
 

--- a/Decimus/Lib/libquicr/QCommon.h
+++ b/Decimus/Lib/libquicr/QCommon.h
@@ -17,14 +17,6 @@ typedef struct QMinMaxAvg {
     uint64_t value_count;
 } QMinMaxAvg;
 
-typedef struct QFullTrackName
-{
-    const char* nameSpace;
-    size_t nameSpaceLength;
-    const char* name;
-    size_t nameLength;
-} QFullTrackName;
-
 typedef struct QObjectHeaders {
     uint64_t groupId;
     uint64_t objectId;
@@ -33,13 +25,4 @@ typedef struct QObjectHeaders {
     const uint16_t* ttl;
 } QObjectHeaders;
 
-
-#ifdef __cplusplus
-static quicr::FullTrackName ftnConvert(QFullTrackName qFtn) {
-    return {
-        .name_space = std::vector<std::uint8_t>(qFtn.nameSpace, qFtn.nameSpace + qFtn.nameSpaceLength),
-        .name = std::vector<std::uint8_t>(qFtn.name, qFtn.name + qFtn.nameLength)
-    };
-}
-#endif
 #endif

--- a/Decimus/Lib/libquicr/QFullTrackName.h
+++ b/Decimus/Lib/libquicr/QFullTrackName.h
@@ -7,7 +7,6 @@
 #import <Foundation/Foundation.h>
 #ifdef __cplusplus
 #include <quicr/track_name.h>
-#include <iostream>
 #endif
 
 @interface QFullTrackName: NSObject

--- a/Decimus/Lib/libquicr/QFullTrackName.h
+++ b/Decimus/Lib/libquicr/QFullTrackName.h
@@ -1,0 +1,29 @@
+// SPDX-FileCopyrightText: Copyright (c) 2023 Cisco Systems
+// SPDX-License-Identifier: BSD-2-Clause
+
+#ifndef QFullTrackName_h
+#define QFullTrackName_h
+
+#import <Foundation/Foundation.h>
+#ifdef __cplusplus
+#include <quicr/track_name.h>
+#include <iostream>
+#endif
+
+@interface QFullTrackName: NSObject
+@property (strong) NSData* name;
+@property (strong) NSData* nameSpace;
+@end
+
+#ifdef __cplusplus
+static quicr::FullTrackName ftnConvert(QFullTrackName* qFtn) {
+    const auto nameSpaceBytes = reinterpret_cast<const std::uint8_t*>(qFtn.nameSpace.bytes);
+    const auto nameBytes = reinterpret_cast<const std::uint8_t*>(qFtn.name.bytes);
+    return {
+        .name_space = std::vector<std::uint8_t>(nameSpaceBytes, nameSpaceBytes + qFtn.nameSpace.length),
+        .name = std::vector<std::uint8_t>(nameBytes, nameBytes + qFtn.name.length)
+    };
+}
+#endif
+
+#endif

--- a/Decimus/Lib/libquicr/QFullTrackName.h
+++ b/Decimus/Lib/libquicr/QFullTrackName.h
@@ -9,13 +9,19 @@
 #include <quicr/track_name.h>
 #endif
 
-@interface QFullTrackName: NSObject
-@property (strong) NSData* name;
-@property (strong) NSData* nameSpace;
+@protocol QFullTrackName
+@property (readonly, strong) NSData* _Nonnull name;
+@property (readonly, strong) NSData* _Nonnull nameSpace;
+@end
+
+@interface QFullTrackNameImpl: NSObject<QFullTrackName>
+@property (strong) NSData* _Nonnull name;
+@property (strong) NSData* _Nonnull nameSpace;
+-(instancetype _Nonnull) initWithNamespace: (NSData* _Nonnull) nameSpace name: (NSData* _Nonnull) name;
 @end
 
 #ifdef __cplusplus
-static quicr::FullTrackName ftnConvert(QFullTrackName* qFtn) {
+static quicr::FullTrackName ftnConvert(id<QFullTrackName> _Nonnull qFtn) {
     const auto nameSpaceBytes = reinterpret_cast<const std::uint8_t*>(qFtn.nameSpace.bytes);
     const auto nameBytes = reinterpret_cast<const std::uint8_t*>(qFtn.name.bytes);
     return {

--- a/Decimus/Lib/libquicr/QFullTrackName.mm
+++ b/Decimus/Lib/libquicr/QFullTrackName.mm
@@ -1,0 +1,8 @@
+// SPDX-FileCopyrightText: Copyright (c) 2023 Cisco Systems
+// SPDX-License-Identifier: BSD-2-Clause
+
+#import "QFullTrackName.h"
+
+// Empty implementation for QFullTrackName
+@implementation QFullTrackName
+@end

--- a/Decimus/Lib/libquicr/QFullTrackName.mm
+++ b/Decimus/Lib/libquicr/QFullTrackName.mm
@@ -4,5 +4,12 @@
 #import "QFullTrackName.h"
 
 // Empty implementation for QFullTrackName
-@implementation QFullTrackName
+@implementation QFullTrackNameImpl
+
+-(instancetype _Nonnull) initWithNamespace: (NSData* _Nonnull) nameSpace name: (NSData* _Nonnull) name {
+    self.nameSpace = nameSpace;
+    self.name = name;
+    return self;
+}
+
 @end

--- a/Decimus/Lib/libquicr/QPublishTrackHandlerObjC.h
+++ b/Decimus/Lib/libquicr/QPublishTrackHandlerObjC.h
@@ -45,7 +45,7 @@ typedef NS_ENUM(uint8_t, QPublishObjectStatus) {
 #endif
 }
 
--(id _Nonnull) initWithFullTrackName: (QFullTrackName* _Nonnull) full_track_name trackMode: (QTrackMode) track_mode defaultPriority: (uint8_t) priority defaultTTL: (uint32_t) ttl;
+-(id _Nonnull) initWithFullTrackName: (id<QFullTrackName> _Nonnull) full_track_name trackMode: (QTrackMode) track_mode defaultPriority: (uint8_t) priority defaultTTL: (uint32_t) ttl;
 -(QPublishObjectStatus)publishObject: (QObjectHeaders) objectHeaders data: (NSData* _Nonnull) data extensions: (NSDictionary<NSNumber*, NSData*>* _Nullable) extensions;
 -(QPublishObjectStatus)publishPartialObject: (QObjectHeaders) objectHeaders data: (NSData* _Nonnull) data extensions: (NSDictionary<NSNumber*, NSData*>* _Nullable) extensions;
 -(void) setCallbacks: (id<QPublishTrackHandlerCallbacks> _Nonnull) callbacks;

--- a/Decimus/Lib/libquicr/QPublishTrackHandlerObjC.h
+++ b/Decimus/Lib/libquicr/QPublishTrackHandlerObjC.h
@@ -9,6 +9,7 @@
 #endif
 
 #import <Foundation/Foundation.h>
+#import "QFullTrackName.h"
 #import "QPublishTrackHandlerCallbacks.h"
 #import "QCommon.h"
 
@@ -44,7 +45,7 @@ typedef NS_ENUM(uint8_t, QPublishObjectStatus) {
 #endif
 }
 
--(id _Nonnull) initWithFullTrackName: (QFullTrackName) full_track_name trackMode: (QTrackMode) track_mode defaultPriority: (uint8_t) priority defaultTTL: (uint32_t) ttl;
+-(id _Nonnull) initWithFullTrackName: (QFullTrackName* _Nonnull) full_track_name trackMode: (QTrackMode) track_mode defaultPriority: (uint8_t) priority defaultTTL: (uint32_t) ttl;
 -(QPublishObjectStatus)publishObject: (QObjectHeaders) objectHeaders data: (NSData* _Nonnull) data extensions: (NSDictionary<NSNumber*, NSData*>* _Nullable) extensions;
 -(QPublishObjectStatus)publishPartialObject: (QObjectHeaders) objectHeaders data: (NSData* _Nonnull) data extensions: (NSDictionary<NSNumber*, NSData*>* _Nullable) extensions;
 -(void) setCallbacks: (id<QPublishTrackHandlerCallbacks> _Nonnull) callbacks;

--- a/Decimus/Lib/libquicr/QPublishTrackHandlerObjC.mm
+++ b/Decimus/Lib/libquicr/QPublishTrackHandlerObjC.mm
@@ -8,7 +8,7 @@
 
 @implementation QPublishTrackHandlerObjC : NSObject
 
--(id) initWithFullTrackName: (QFullTrackName*) full_track_name trackMode: (QTrackMode) track_mode defaultPriority: (uint8_t) priority defaultTTL: (uint32_t) ttl
+-(id) initWithFullTrackName: (id<QFullTrackName>) full_track_name trackMode: (QTrackMode) track_mode defaultPriority: (uint8_t) priority defaultTTL: (uint32_t) ttl
 {
     quicr::FullTrackName fullTrackName = ftnConvert(full_track_name);
     quicr::TrackMode moqTrackMode = (quicr::TrackMode)track_mode;

--- a/Decimus/Lib/libquicr/QPublishTrackHandlerObjC.mm
+++ b/Decimus/Lib/libquicr/QPublishTrackHandlerObjC.mm
@@ -8,7 +8,7 @@
 
 @implementation QPublishTrackHandlerObjC : NSObject
 
--(id) initWithFullTrackName: (QFullTrackName) full_track_name trackMode: (QTrackMode) track_mode defaultPriority: (uint8_t) priority defaultTTL: (uint32_t) ttl
+-(id) initWithFullTrackName: (QFullTrackName*) full_track_name trackMode: (QTrackMode) track_mode defaultPriority: (uint8_t) priority defaultTTL: (uint32_t) ttl
 {
     quicr::FullTrackName fullTrackName = ftnConvert(full_track_name);
     quicr::TrackMode moqTrackMode = (quicr::TrackMode)track_mode;

--- a/Decimus/Lib/libquicr/QSubscribeTrackHandlerObjC.h
+++ b/Decimus/Lib/libquicr/QSubscribeTrackHandlerObjC.h
@@ -21,9 +21,9 @@
 #endif
 }
 
--(id _Nonnull) initWithFullTrackName: (QFullTrackName* _Nonnull) full_track_name;
+-(id _Nonnull) initWithFullTrackName: (id<QFullTrackName> _Nonnull) full_track_name;
 -(QSubscribeTrackHandlerStatus) getStatus;
--(QFullTrackName* _Nonnull) getFullTrackName;
+-(id<QFullTrackName> _Nonnull) getFullTrackName;
 -(void)setCallbacks: (id<QSubscribeTrackHandlerCallbacks> _Nonnull) callbacks;
 
 @end

--- a/Decimus/Lib/libquicr/QSubscribeTrackHandlerObjC.h
+++ b/Decimus/Lib/libquicr/QSubscribeTrackHandlerObjC.h
@@ -11,6 +11,7 @@
 #import <Foundation/Foundation.h>
 #import "QCommon.h"
 #import "QSubscribeTrackHandlerCallbacks.h"
+#import "QFullTrackName.h"
 
 @interface QSubscribeTrackHandlerObjC : NSObject
 {
@@ -20,10 +21,10 @@
 #endif
 }
 
--(id) initWithFullTrackName: (QFullTrackName) full_track_name;
+-(id _Nonnull) initWithFullTrackName: (QFullTrackName* _Nonnull) full_track_name;
 -(QSubscribeTrackHandlerStatus) getStatus;
--(QFullTrackName) getFullTrackName;
--(void)setCallbacks: (id<QSubscribeTrackHandlerCallbacks>) callbacks;
+-(QFullTrackName* _Nonnull) getFullTrackName;
+-(void)setCallbacks: (id<QSubscribeTrackHandlerCallbacks> _Nonnull) callbacks;
 
 @end
 

--- a/Decimus/Lib/libquicr/QSubscribeTrackHandlerObjC.h
+++ b/Decimus/Lib/libquicr/QSubscribeTrackHandlerObjC.h
@@ -22,7 +22,7 @@
 
 -(id) initWithFullTrackName: (QFullTrackName) full_track_name;
 -(QSubscribeTrackHandlerStatus) getStatus;
-
+-(QFullTrackName) getFullTrackName;
 -(void)setCallbacks: (id<QSubscribeTrackHandlerCallbacks>) callbacks;
 
 @end

--- a/Decimus/Lib/libquicr/QSubscribeTrackHandlerObjC.mm
+++ b/Decimus/Lib/libquicr/QSubscribeTrackHandlerObjC.mm
@@ -7,7 +7,7 @@
 
 @implementation QSubscribeTrackHandlerObjC : NSObject
 
--(id) initWithFullTrackName: (QFullTrackName*) full_track_name
+-(id) initWithFullTrackName: (id<QFullTrackName>) full_track_name
 {
     quicr::FullTrackName fullTrackName = ftnConvert(full_track_name);
     handlerPtr = std::make_shared<QSubscribeTrackHandler>(fullTrackName);
@@ -20,10 +20,10 @@
     return static_cast<QSubscribeTrackHandlerStatus>(status);
 }
 
--(QFullTrackName*) getFullTrackName {
+-(id<QFullTrackName>) getFullTrackName {
     assert(handlerPtr);
     const auto ftn = handlerPtr->GetFullTrackName();
-    const auto converted = [[QFullTrackName alloc] init];
+    const auto converted = [[QFullTrackNameImpl alloc] init];
     NSData* nameSpace = [[NSData alloc] initWithBytes:(void*)ftn.name_space.data()  length:ftn.name_space.size()];
     converted.nameSpace = nameSpace;
     NSData* name = [[NSData alloc] initWithBytes:(void*)ftn.name.data()  length:ftn.name.size()];

--- a/Decimus/Lib/libquicr/QSubscribeTrackHandlerObjC.mm
+++ b/Decimus/Lib/libquicr/QSubscribeTrackHandlerObjC.mm
@@ -7,7 +7,7 @@
 
 @implementation QSubscribeTrackHandlerObjC : NSObject
 
--(id) initWithFullTrackName: (QFullTrackName) full_track_name
+-(id) initWithFullTrackName: (QFullTrackName*) full_track_name
 {
     quicr::FullTrackName fullTrackName = ftnConvert(full_track_name);
     handlerPtr = std::make_shared<QSubscribeTrackHandler>(fullTrackName);
@@ -18,6 +18,17 @@
     assert(handlerPtr);
     auto status = handlerPtr->GetStatus();
     return static_cast<QSubscribeTrackHandlerStatus>(status);
+}
+
+-(QFullTrackName*) getFullTrackName {
+    assert(handlerPtr);
+    const auto ftn = handlerPtr->GetFullTrackName();
+    const auto converted = [[QFullTrackName alloc] init];
+    NSData* nameSpace = [[NSData alloc] initWithBytes:(void*)ftn.name_space.data()  length:ftn.name_space.size()];
+    converted.nameSpace = nameSpace;
+    NSData* name = [[NSData alloc] initWithBytes:(void*)ftn.name.data()  length:ftn.name.size()];
+    converted.name = name;
+    return converted;
 }
 
 -(void) setCallbacks: (id<QSubscribeTrackHandlerCallbacks>) callbacks

--- a/Decimus/Publications/Publication.swift
+++ b/Decimus/Publications/Publication.swift
@@ -32,7 +32,7 @@ class Publication: QPublishTrackHandlerObjC, QPublishTrackHandlerCallbacks {
             self.measurement = nil
         }
         let fullTrackName = try FullTrackName(namespace: profile.namespace, name: "")
-        super.init(fullTrackName: fullTrackName.get(),
+        super.init(fullTrackName: fullTrackName,
                    trackMode: trackMode,
                    defaultPriority: defaultPriority,
                    defaultTTL: UInt32(defaultTTL))

--- a/Decimus/Publications/Publication.swift
+++ b/Decimus/Publications/Publication.swift
@@ -32,7 +32,7 @@ class Publication: QPublishTrackHandlerObjC, QPublishTrackHandlerCallbacks {
             self.measurement = nil
         }
         let fullTrackName = try FullTrackName(namespace: profile.namespace, name: "")
-        super.init(fullTrackName: fullTrackName.getUnsafe(),
+        super.init(fullTrackName: fullTrackName.get(),
                    trackMode: trackMode,
                    defaultPriority: defaultPriority,
                    defaultTTL: UInt32(defaultTTL))

--- a/Decimus/Publications/PublicationFactory.swift
+++ b/Decimus/Publications/PublicationFactory.swift
@@ -4,7 +4,11 @@
 import Foundation
 import AVFoundation
 
-class PublicationFactory {
+protocol PublicationFactory {
+    func create(publication: ManifestPublication, endpointId: String, relayId: String) throws -> [(FullTrackName, QPublishTrackHandlerObjC)]
+}
+
+class PublicationFactoryImpl: PublicationFactory {
     private let opusWindowSize: OpusWindowSize
     private let reliability: MediaReliability
     private let granularMetrics: Bool

--- a/Decimus/Subscriptions/ActiveSpeakerControl.swift
+++ b/Decimus/Subscriptions/ActiveSpeakerControl.swift
@@ -1,6 +1,0 @@
-// SPDX-FileCopyrightText: Copyright (c) 2023 Cisco Systems
-// SPDX-License-Identifier: BSD-2-Clause
-
-class ActiveSpeakerControl: QSubscribeTrackHandlerObjC {
-
-}

--- a/Decimus/Subscriptions/ActiveSpeakerControl.swift
+++ b/Decimus/Subscriptions/ActiveSpeakerControl.swift
@@ -1,0 +1,6 @@
+// SPDX-FileCopyrightText: Copyright (c) 2023 Cisco Systems
+// SPDX-License-Identifier: BSD-2-Clause
+
+class ActiveSpeakerControl: QSubscribeTrackHandlerObjC {
+
+}

--- a/Decimus/Subscriptions/OpusSubscription.swift
+++ b/Decimus/Subscriptions/OpusSubscription.swift
@@ -76,7 +76,7 @@ class OpusSubscription: QSubscribeTrackHandlerObjC, SubscriptionSet, QSubscribeT
                                  metricsSubmitter: self.metricsSubmitter)
         let fullTrackName = try FullTrackName(namespace: profile.namespace, name: "")
         self.fullTrackName = fullTrackName
-        super.init(fullTrackName: fullTrackName.getUnsafe())
+        super.init(fullTrackName: fullTrackName.get())
         self.setCallbacks(self)
 
         // Make task for cleaning up audio handlers.

--- a/Decimus/Subscriptions/OpusSubscription.swift
+++ b/Decimus/Subscriptions/OpusSubscription.swift
@@ -25,6 +25,7 @@ class OpusSubscription: QSubscribeTrackHandlerObjC, SubscriptionSet, QSubscribeT
     private let subscription: ManifestSubscription
     private let metricsSubmitter: MetricsSubmitter?
     private let useNewJitterBuffer: Bool
+    private let fullTrackName: FullTrackName
 
     init(subscription: ManifestSubscription,
          engine: DecimusAudioEngine,
@@ -74,6 +75,7 @@ class OpusSubscription: QSubscribeTrackHandlerObjC, SubscriptionSet, QSubscribeT
                                  useNewJitterBuffer: self.useNewJitterBuffer,
                                  metricsSubmitter: self.metricsSubmitter)
         let fullTrackName = try FullTrackName(namespace: profile.namespace, name: "")
+        self.fullTrackName = fullTrackName
         super.init(fullTrackName: fullTrackName.getUnsafe())
         self.setCallbacks(self)
 
@@ -107,8 +109,8 @@ class OpusSubscription: QSubscribeTrackHandlerObjC, SubscriptionSet, QSubscribeT
         Self.logger.debug("Deinit")
     }
 
-    func getHandlers() -> [QSubscribeTrackHandlerObjC] {
-        return [self]
+    func getHandlers() -> [FullTrackName: QSubscribeTrackHandlerObjC] {
+        return [self.fullTrackName: self]
     }
 
     func statusChanged(_ status: QSubscribeTrackHandlerStatus) {

--- a/Decimus/Subscriptions/OpusSubscription.swift
+++ b/Decimus/Subscriptions/OpusSubscription.swift
@@ -76,7 +76,7 @@ class OpusSubscription: QSubscribeTrackHandlerObjC, SubscriptionSet, QSubscribeT
                                  metricsSubmitter: self.metricsSubmitter)
         let fullTrackName = try FullTrackName(namespace: profile.namespace, name: "")
         self.fullTrackName = fullTrackName
-        super.init(fullTrackName: fullTrackName.get())
+        super.init(fullTrackName: fullTrackName)
         self.setCallbacks(self)
 
         // Make task for cleaning up audio handlers.

--- a/Decimus/Subscriptions/VideoSubscription.swift
+++ b/Decimus/Subscriptions/VideoSubscription.swift
@@ -77,7 +77,7 @@ class VideoSubscription: QSubscribeTrackHandlerObjC, QSubscribeTrackHandlerCallb
                                        variances: variances)
         self.token = handler.registerCallback(callback)
         self.handler = handler
-        super.init(fullTrackName: fullTrackName.get())
+        super.init(fullTrackName: fullTrackName)
         self.setCallbacks(self)
     }
 

--- a/Decimus/Subscriptions/VideoSubscription.swift
+++ b/Decimus/Subscriptions/VideoSubscription.swift
@@ -77,8 +77,7 @@ class VideoSubscription: QSubscribeTrackHandlerObjC, QSubscribeTrackHandlerCallb
                                        variances: variances)
         self.token = handler.registerCallback(callback)
         self.handler = handler
-
-        super.init(fullTrackName: fullTrackName.getUnsafe())
+        super.init(fullTrackName: fullTrackName.get())
         self.setCallbacks(self)
     }
 

--- a/Decimus/Subscriptions/VideoSubscriptionSet.swift
+++ b/Decimus/Subscriptions/VideoSubscriptionSet.swift
@@ -149,12 +149,8 @@ class VideoSubscriptionSet: SubscriptionSet {
         Self.logger.debug("Deinit")
     }
 
-    func getHandlers() -> [QSubscribeTrackHandlerObjC] {
-        var handlers: [QSubscribeTrackHandlerObjC] = []
-        for handler in self.videoSubscriptions {
-            handlers.append(handler.value)
-        }
-        return handlers
+    func getHandlers() -> [FullTrackName: QSubscribeTrackHandlerObjC] {
+        self.videoSubscriptions
     }
 
     private func receivedObject(timestamp: TimeInterval, when: Date) {

--- a/Decimus/Views/InCallView.swift
+++ b/Decimus/Views/InCallView.swift
@@ -320,12 +320,7 @@ extension InCallView {
                     }
                     return .init(endpointUri: endpointId,
                                  client: client,
-                                 captureManager: captureManager,
-                                 subscriptionConfig: subConfig,
-                                 engine: engine,
-                                 videoParticipants: self.videoParticipants,
-                                 submitter: self.submitter,
-                                 granularMetrics: influxConfig.value.granular) {
+                                 submitter: self.submitter) {
                         DispatchQueue.main.async {
                             onLeave()
                         }

--- a/Decimus/Views/InCallView.swift
+++ b/Decimus/Views/InCallView.swift
@@ -227,6 +227,8 @@ extension InCallView {
         private var videoCapture = false
         private let onLeave: () -> Void
         var relayId: String?
+        private var publicationFactory: PublicationFactory?
+        private var subscriptionFactory: SubscriptionFactory?
 
         @AppStorage(SubscriptionSettingsView.showLabelsKey)
         var showLabels: Bool = true
@@ -266,6 +268,17 @@ extension InCallView {
 
             if let captureManager = self.captureManager,
                let engine = self.engine {
+                self.publicationFactory = PublicationFactoryImpl(opusWindowSize: self.subscriptionConfig.value.opusWindowSize,
+                                                                 reliability: self.subscriptionConfig.value.mediaReliability,
+                                                                 engine: engine,
+                                                                 metricsSubmitter: self.submitter,
+                                                                 granularMetrics: self.influxConfig.value.granular,
+                                                                 captureManager: captureManager)
+                self.subscriptionFactory = SubscriptionFactoryImpl(videoParticipants: self.videoParticipants,
+                                                                   metricsSubmitter: self.submitter,
+                                                                   subscriptionConfig: self.subscriptionConfig.value,
+                                                                   granularMetrics: self.influxConfig.value.granular,
+                                                                   engine: engine)
                 let connectUri: String = "moq://\(config.address):\(config.port)"
                 let endpointId: String = config.email
                 let qLogPath: URL
@@ -297,7 +310,16 @@ extension InCallView {
                                               endpointUri: endpointId,
                                               transportConfig: tConfig,
                                               metricsSampleMs: 0)
-                    return .init(config: config,
+                    let client = config.connectUri.withCString { connectUri in
+                        config.endpointUri.withCString { endpointId in
+                            QClientObjC(config: .init(connectUri: connectUri,
+                                                      endpointId: endpointId,
+                                                      transportConfig: config.transportConfig,
+                                                      metricsSampleMs: config.metricsSampleMs))
+                        }
+                    }
+                    return .init(endpointUri: endpointId,
+                                 client: client,
                                  captureManager: captureManager,
                                  subscriptionConfig: subConfig,
                                  engine: engine,
@@ -348,7 +370,13 @@ extension InCallView {
 
             // Inject the manifest in order to create publications & subscriptions.
             do {
-                try controller.setManifest(manifest)
+                guard let publicationFactory = self.publicationFactory,
+                      let subscriptionFactory = self.subscriptionFactory else {
+                    throw "Missing factory"
+                }
+                try controller.setManifest(manifest,
+                                           publicationFactory: publicationFactory,
+                                           subscriptionFactory: subscriptionFactory)
             } catch {
                 Self.logger.error("Failed to set manifest: \(error.localizedDescription)")
                 return false

--- a/Decimus/Views/InCallView.swift
+++ b/Decimus/Views/InCallView.swift
@@ -365,13 +365,21 @@ extension InCallView {
 
             // Inject the manifest in order to create publications & subscriptions.
             do {
+                // Unwrap factory optionals.
                 guard let publicationFactory = self.publicationFactory,
                       let subscriptionFactory = self.subscriptionFactory else {
                     throw "Missing factory"
                 }
-                try controller.setManifest(manifest,
-                                           publicationFactory: publicationFactory,
-                                           subscriptionFactory: subscriptionFactory)
+
+                // Publish.
+                for publication in manifest.publications {
+                    try controller.publish(details: publication, factory: publicationFactory)
+                }
+
+                // Subscribe.
+                for subscription in manifest.subscriptions {
+                    try controller.subscribeToSet(details: subscription, factory: subscriptionFactory)
+                }
             } catch {
                 Self.logger.error("Failed to set manifest: \(error.localizedDescription)")
                 return false

--- a/QuicR.xcodeproj/project.pbxproj
+++ b/QuicR.xcodeproj/project.pbxproj
@@ -58,6 +58,7 @@
 		9B1F2C122C948ECE007548D1 /* TrackMeasurement.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B1F2C112C948ECB007548D1 /* TrackMeasurement.swift */; };
 		9B308B992CAAEE7400BF2361 /* LabeledToggle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B308B982CAAEE6F00BF2361 /* LabeledToggle.swift */; };
 		9B3E44172C8F1FD60000B98D /* Publication.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B3E44162C8F1FD60000B98D /* Publication.swift */; };
+		9B3F2C9B2CD23FF90053CBC1 /* ActiveSpeakerControl.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B3F2C9A2CD23FF50053CBC1 /* ActiveSpeakerControl.swift */; };
 		9B3F86852C58F4B800B5B8BA /* CircularBuffer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B3F86842C58F4B800B5B8BA /* CircularBuffer.swift */; };
 		9B4788D42B972F990056CE7E /* TestVideoSubscriptionSet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B4788D32B972F990056CE7E /* TestVideoSubscriptionSet.swift */; };
 		9B480662297EAF170040F5D4 /* InCallView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B480661297EAF170040F5D4 /* InCallView.swift */; };
@@ -234,6 +235,7 @@
 		9B1F2C112C948ECB007548D1 /* TrackMeasurement.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrackMeasurement.swift; sourceTree = "<group>"; };
 		9B308B982CAAEE6F00BF2361 /* LabeledToggle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LabeledToggle.swift; sourceTree = "<group>"; };
 		9B3E44162C8F1FD60000B98D /* Publication.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Publication.swift; sourceTree = "<group>"; };
+		9B3F2C9A2CD23FF50053CBC1 /* ActiveSpeakerControl.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActiveSpeakerControl.swift; sourceTree = "<group>"; };
 		9B3F86842C58F4B800B5B8BA /* CircularBuffer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CircularBuffer.swift; sourceTree = "<group>"; };
 		9B4788D32B972F990056CE7E /* TestVideoSubscriptionSet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestVideoSubscriptionSet.swift; sourceTree = "<group>"; };
 		9B480661297EAF170040F5D4 /* InCallView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InCallView.swift; sourceTree = "<group>"; };
@@ -639,6 +641,7 @@
 		FF2498B52A55E8F800C6D66D /* Subscriptions */ = {
 			isa = PBXGroup;
 			children = (
+				9B3F2C9A2CD23FF50053CBC1 /* ActiveSpeakerControl.swift */,
 				184912872A3A51FC00773D39 /* OpusSubscription.swift */,
 				FF2498B62A55E95E00C6D66D /* VideoSubscriptionSet.swift */,
 				FF2498B32A55E8CC00C6D66D /* SubscriptionFactory.swift */,
@@ -895,7 +898,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "$SRCROOT/dependencies/build-qmedia-framework.sh\n";
+			shellScript = "#$SRCROOT/dependencies/build-qmedia-framework.sh\n";
 		};
 /* End PBXShellScriptBuildPhase section */
 
@@ -1011,6 +1014,7 @@
 				FF1C5C2E29DD110600887833 /* LeaveModal.swift in Sources */,
 				186763592B2B6B3B00339421 /* JitterBuffer+Measurement.swift in Sources */,
 				FFFF72DD2A280B6300D4D5EE /* ManifestSettingsView.swift in Sources */,
+				9B3F2C9B2CD23FF90053CBC1 /* ActiveSpeakerControl.swift in Sources */,
 				18C89A4B2A14EF1F005B333B /* InfluxSettingsView.swift in Sources */,
 				18BF45712B0CD632006E8E24 /* VTEncoder.swift in Sources */,
 				180E74642B0E4F5E0045B9D6 /* VideoHandler.swift in Sources */,
@@ -1038,7 +1042,7 @@
 				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = "";
+				DEVELOPMENT_TEAM = R77C67VW87;
 				GENERATE_INFOPLIST_FILE = YES;
 				HEADER_SEARCH_PATHS = "$(inherited)";
 				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
@@ -1063,7 +1067,7 @@
 				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = "";
+				DEVELOPMENT_TEAM = R77C67VW87;
 				GENERATE_INFOPLIST_FILE = YES;
 				HEADER_SEARCH_PATHS = "$(inherited)";
 				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
@@ -1229,7 +1233,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_ASSET_PATHS = "\"Decimus/Preview Content\"";
-				DEVELOPMENT_TEAM = "";
+				DEVELOPMENT_TEAM = R77C67VW87;
 				"ENABLE_HARDENED_RUNTIME[sdk=macosx*]" = YES;
 				ENABLE_PREVIEWS = YES;
 				FRAMEWORK_SEARCH_PATHS = "";
@@ -1304,7 +1308,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_ASSET_PATHS = "\"Decimus/Preview Content\"";
-				DEVELOPMENT_TEAM = "";
+				DEVELOPMENT_TEAM = R77C67VW87;
 				"ENABLE_HARDENED_RUNTIME[sdk=macosx*]" = YES;
 				ENABLE_PREVIEWS = YES;
 				FRAMEWORK_SEARCH_PATHS = "";

--- a/QuicR.xcodeproj/project.pbxproj
+++ b/QuicR.xcodeproj/project.pbxproj
@@ -59,7 +59,6 @@
 		9B1F2C122C948ECE007548D1 /* TrackMeasurement.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B1F2C112C948ECB007548D1 /* TrackMeasurement.swift */; };
 		9B308B992CAAEE7400BF2361 /* LabeledToggle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B308B982CAAEE6F00BF2361 /* LabeledToggle.swift */; };
 		9B3E44172C8F1FD60000B98D /* Publication.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B3E44162C8F1FD60000B98D /* Publication.swift */; };
-		9B3F2C9B2CD23FF90053CBC1 /* ActiveSpeakerControl.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B3F2C9A2CD23FF50053CBC1 /* ActiveSpeakerControl.swift */; };
 		9B3F86852C58F4B800B5B8BA /* CircularBuffer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B3F86842C58F4B800B5B8BA /* CircularBuffer.swift */; };
 		9B4788D42B972F990056CE7E /* TestVideoSubscriptionSet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B4788D32B972F990056CE7E /* TestVideoSubscriptionSet.swift */; };
 		9B480662297EAF170040F5D4 /* InCallView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B480661297EAF170040F5D4 /* InCallView.swift */; };
@@ -237,7 +236,6 @@
 		9B1F2C112C948ECB007548D1 /* TrackMeasurement.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrackMeasurement.swift; sourceTree = "<group>"; };
 		9B308B982CAAEE6F00BF2361 /* LabeledToggle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LabeledToggle.swift; sourceTree = "<group>"; };
 		9B3E44162C8F1FD60000B98D /* Publication.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Publication.swift; sourceTree = "<group>"; };
-		9B3F2C9A2CD23FF50053CBC1 /* ActiveSpeakerControl.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActiveSpeakerControl.swift; sourceTree = "<group>"; };
 		9B3F86842C58F4B800B5B8BA /* CircularBuffer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CircularBuffer.swift; sourceTree = "<group>"; };
 		9B4788D32B972F990056CE7E /* TestVideoSubscriptionSet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestVideoSubscriptionSet.swift; sourceTree = "<group>"; };
 		9B480661297EAF170040F5D4 /* InCallView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InCallView.swift; sourceTree = "<group>"; };
@@ -646,7 +644,6 @@
 		FF2498B52A55E8F800C6D66D /* Subscriptions */ = {
 			isa = PBXGroup;
 			children = (
-				9B3F2C9A2CD23FF50053CBC1 /* ActiveSpeakerControl.swift */,
 				184912872A3A51FC00773D39 /* OpusSubscription.swift */,
 				FF2498B62A55E95E00C6D66D /* VideoSubscriptionSet.swift */,
 				FF2498B32A55E8CC00C6D66D /* SubscriptionFactory.swift */,
@@ -903,7 +900,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "#$SRCROOT/dependencies/build-qmedia-framework.sh\n";
+			shellScript = "$SRCROOT/dependencies/build-qmedia-framework.sh\n";
 		};
 /* End PBXShellScriptBuildPhase section */
 
@@ -1020,7 +1017,6 @@
 				FF1C5C2E29DD110600887833 /* LeaveModal.swift in Sources */,
 				186763592B2B6B3B00339421 /* JitterBuffer+Measurement.swift in Sources */,
 				FFFF72DD2A280B6300D4D5EE /* ManifestSettingsView.swift in Sources */,
-				9B3F2C9B2CD23FF90053CBC1 /* ActiveSpeakerControl.swift in Sources */,
 				18C89A4B2A14EF1F005B333B /* InfluxSettingsView.swift in Sources */,
 				18BF45712B0CD632006E8E24 /* VTEncoder.swift in Sources */,
 				180E74642B0E4F5E0045B9D6 /* VideoHandler.swift in Sources */,
@@ -1048,7 +1044,7 @@
 				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = R77C67VW87;
+				DEVELOPMENT_TEAM = "";
 				GENERATE_INFOPLIST_FILE = YES;
 				HEADER_SEARCH_PATHS = "$(inherited)";
 				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
@@ -1073,7 +1069,7 @@
 				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = R77C67VW87;
+				DEVELOPMENT_TEAM = "";
 				GENERATE_INFOPLIST_FILE = YES;
 				HEADER_SEARCH_PATHS = "$(inherited)";
 				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
@@ -1239,7 +1235,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_ASSET_PATHS = "\"Decimus/Preview Content\"";
-				DEVELOPMENT_TEAM = R77C67VW87;
+				DEVELOPMENT_TEAM = "";
 				"ENABLE_HARDENED_RUNTIME[sdk=macosx*]" = YES;
 				ENABLE_PREVIEWS = YES;
 				FRAMEWORK_SEARCH_PATHS = "";
@@ -1314,7 +1310,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_ASSET_PATHS = "\"Decimus/Preview Content\"";
-				DEVELOPMENT_TEAM = R77C67VW87;
+				DEVELOPMENT_TEAM = "";
 				"ENABLE_HARDENED_RUNTIME[sdk=macosx*]" = YES;
 				ENABLE_PREVIEWS = YES;
 				FRAMEWORK_SEARCH_PATHS = "";

--- a/QuicR.xcodeproj/project.pbxproj
+++ b/QuicR.xcodeproj/project.pbxproj
@@ -49,6 +49,7 @@
 		18F7C4DA2AB1C7BD005EDB88 /* OrderedCollections in Frameworks */ = {isa = PBXBuildFile; productRef = 18F7C4D92AB1C7BD005EDB88 /* OrderedCollections */; };
 		9B0E0F1C2C4A9A0300F06D6E /* TestNumberView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B0E0F1B2C4A9A0300F06D6E /* TestNumberView.swift */; };
 		9B1143BB2BADBC0A003A2D2D /* VideoSubscriptionSet+Measurement.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B1143BA2BADBC0A003A2D2D /* VideoSubscriptionSet+Measurement.swift */; };
+		9B1246322CD8EB83004C020C /* QFullTrackName.mm in Sources */ = {isa = PBXBuildFile; fileRef = 9B1246312CD8EB7F004C020C /* QFullTrackName.mm */; };
 		9B131C672B7E467500B29D77 /* ApplicationH264SEIs.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B131C662B7E467500B29D77 /* ApplicationH264SEIs.swift */; };
 		9B131C692B7E476500B29D77 /* DecimusVideoFrame.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B131C682B7E476500B29D77 /* DecimusVideoFrame.swift */; };
 		9B131E332B7E4A1C00B29D77 /* ApplicationHEVCSEIs.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B131E322B7E4A1C00B29D77 /* ApplicationHEVCSEIs.swift */; };
@@ -226,6 +227,7 @@
 		18F7C4D72AB1C7AA005EDB88 /* JitterBuffer.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = JitterBuffer.swift; sourceTree = "<group>"; };
 		9B0E0F1B2C4A9A0300F06D6E /* TestNumberView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestNumberView.swift; sourceTree = "<group>"; };
 		9B1143BA2BADBC0A003A2D2D /* VideoSubscriptionSet+Measurement.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "VideoSubscriptionSet+Measurement.swift"; sourceTree = "<group>"; };
+		9B1246312CD8EB7F004C020C /* QFullTrackName.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = QFullTrackName.mm; sourceTree = "<group>"; };
 		9B131C662B7E467500B29D77 /* ApplicationH264SEIs.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApplicationH264SEIs.swift; sourceTree = "<group>"; };
 		9B131C682B7E476500B29D77 /* DecimusVideoFrame.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DecimusVideoFrame.swift; sourceTree = "<group>"; };
 		9B131E322B7E4A1C00B29D77 /* ApplicationHEVCSEIs.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApplicationHEVCSEIs.swift; sourceTree = "<group>"; };
@@ -244,6 +246,7 @@
 		9B48068B298301FD0040F5D4 /* QMediaTypes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QMediaTypes.swift; sourceTree = "<group>"; };
 		9B61384D2C904E25006E5E11 /* VideoSubscription.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VideoSubscription.swift; sourceTree = "<group>"; };
 		9B61384F2C90893C006E5E11 /* TestPublication.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestPublication.swift; sourceTree = "<group>"; };
+		9B749B882CD8E3CD002E0FC7 /* QFullTrackName.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = QFullTrackName.h; sourceTree = "<group>"; };
 		9B7F40012ACB1914003333C3 /* H264Utilities.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = H264Utilities.swift; sourceTree = "<group>"; };
 		9B7F40032ACB5808003333C3 /* TestVideoUtilities.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestVideoUtilities.swift; sourceTree = "<group>"; };
 		9B85951429F03147008C813C /* TestPlan.xctestplan */ = {isa = PBXFileReference; lastKnownFileType = text; path = TestPlan.xctestplan; sourceTree = "<group>"; };
@@ -484,6 +487,8 @@
 		9B8E14DA2C7E935E009D8C24 /* libquicr */ = {
 			isa = PBXGroup;
 			children = (
+				9B1246312CD8EB7F004C020C /* QFullTrackName.mm */,
+				9B749B882CD8E3CD002E0FC7 /* QFullTrackName.h */,
 				9BDA15D02C7FD83700494BFD /* FullTrackName.swift */,
 				9BDA15CF2C7F429D00494BFD /* QSubscribeTrackHandlerCallbacks.h */,
 				9B8E14E02C7E997A009D8C24 /* QPublishTrackHandlerCallbacks.h */,
@@ -1001,6 +1006,7 @@
 				FF2498B02A534E8E00C6D66D /* H264Publication.swift in Sources */,
 				9BAD55BD29B0B77700D9B65F /* ErrorWriter.swift in Sources */,
 				9BC53C9E2BFE0AA000BB39C6 /* VarianceCalculator+Measurement.swift in Sources */,
+				9B1246322CD8EB83004C020C /* QFullTrackName.mm in Sources */,
 				9BC53C9C2BFE075300BB39C6 /* VarianceCalculator.swift in Sources */,
 				18C89A402A13D334005B333B /* InfluxMetricsSubmitter.swift in Sources */,
 				9B48066E297F19700040F5D4 /* CaptureManager.swift in Sources */,

--- a/Tests/TestCallController.swift
+++ b/Tests/TestCallController.swift
@@ -4,32 +4,6 @@
 import XCTest
 @testable import QuicR
 
-final class TestFullTrackName: XCTestCase {
-    /// Test compatbility between Swift and Objective-C representations of ``FullTrackName``.
-    func testBidirectional() throws {
-        // FTN roundtrip.
-        let namespace = "namespace"
-        let name = "name"
-        let ftn = try FullTrackName(namespace: namespace, name: name)
-        XCTAssertEqual(try ftn.getName(), name)
-        XCTAssertEqual(try ftn.getNamespace(), namespace)
-        let qFullTrackName = ftn.get()
-        let reconstructed = FullTrackName(qFullTrackName)
-        XCTAssertEqual(try reconstructed.getName(), name)
-        XCTAssertEqual(try reconstructed.getNamespace(), namespace)
-
-        // QFullTrackName.
-        let qftn = QFullTrackName()
-        qftn.nameSpace = namespace.data(using: .ascii)!
-        qftn.name = name.data(using: .ascii)!
-        let swift = FullTrackName(qftn)
-        XCTAssertEqual(swift.name, qftn.name)
-        XCTAssertEqual(swift.namespace, qftn.nameSpace)
-        XCTAssertEqual(try swift.getName(), name)
-        XCTAssertEqual(try swift.getNamespace(), namespace)
-    }
-}
-
 final class TestCallController: XCTestCase {
 
     class MockPublicationFactory: PublicationFactory {
@@ -77,7 +51,7 @@ final class TestCallController: XCTestCase {
 
     class MockSubscription: QSubscribeTrackHandlerObjC {
         init(ftn: FullTrackName) {
-            super.init(fullTrackName: ftn.get())
+            super.init(fullTrackName: ftn)
         }
     }
 
@@ -224,7 +198,7 @@ final class TestCallController: XCTestCase {
                                                                       namespace: namespace)
                                                              ]))
 
-        let expectedFtn: [FullTrackName] = [try .init(namespace: namespace, name: "")]
+        let expectedFtn: [QFullTrackName] = [try FullTrackName(namespace: namespace, name: "")]
         var factoryCreated: SubscriptionSet?
         let creationCallback: MockSubscriptionFactory.SubscriptionCreated = {
             factoryCreated = $0
@@ -234,13 +208,13 @@ final class TestCallController: XCTestCase {
         // Create controller.
         let publish: MockClient.PublishTrackCallback = { _ in }
         let unpublish: MockClient.UnpublishTrackCallback = { _ in }
-        var subscribed: [FullTrackName] = []
-        var unsubscribed: [FullTrackName] = []
+        var subscribed: [QFullTrackName] = []
+        var unsubscribed: [QFullTrackName] = []
         let subscribe: MockClient.SubscribeTrackCallback = {
-            subscribed.append(FullTrackName($0.getFullTrackName()))
+            subscribed.append($0.getFullTrackName())
         }
         let unsubscribe: MockClient.UnsubscribeTrackCallback = {
-            unsubscribed.append(FullTrackName($0.getFullTrackName()))
+            unsubscribed.append($0.getFullTrackName())
         }
         let client = MockClient(publish: publish, unpublish: unpublish, subscribe: subscribe, unsubscribe: unsubscribe)
         let controller = MoqCallController(endpointUri: "1", client: client, submitter: nil) { }
@@ -250,7 +224,7 @@ final class TestCallController: XCTestCase {
         // and subscribeTrack to be called on all contained subscriptions.
         try controller.subscribeToSet(details: details, factory: factory)
         XCTAssertNotNil(factoryCreated)
-        XCTAssertEqual(subscribed, expectedFtn)
+        XCTAssert(self.assertFtnEquality(subscribed, rhs: expectedFtn))
 
         // Should show as tracked.
         var sets = controller.getSubscriptionSets()
@@ -258,11 +232,29 @@ final class TestCallController: XCTestCase {
 
         // Removing should unsubscribe.
         try controller.unsubscribeToSet(sourceID)
-        XCTAssertEqual(unsubscribed, expectedFtn)
+        XCTAssert(self.assertFtnEquality(unsubscribed, rhs: expectedFtn))
 
         // No sets should be left.
         sets = controller.getSubscriptionSets()
         XCTAssertEqual([], sets)
+    }
+
+    func testAssertFtnEquality() throws {
+        let a: [QFullTrackName] = [try FullTrackName(namespace: "a", name: "a")]
+        let b: [QFullTrackName] = [try FullTrackName(namespace: "b", name: "b")]
+        XCTAssertTrue(self.assertFtnEquality(a, rhs: a))
+        XCTAssertFalse(self.assertFtnEquality(a, rhs: b))
+    }
+
+    func assertFtnEquality(_ lhs: [QFullTrackName], rhs: [QFullTrackName]) -> Bool {
+        guard lhs.count == rhs.count else { return false }
+        var match = true
+        for ftn in lhs {
+            match = match && rhs.contains(where: { other in
+                ftn.name == other.name && ftn.nameSpace == other.nameSpace
+            })
+        }
+        return match
     }
 
     func testMetrics() throws {

--- a/Tests/TestCallController.swift
+++ b/Tests/TestCallController.swift
@@ -6,6 +6,65 @@ import XCTest
 
 final class TestCallController: XCTestCase {
 
+    class MockPublicationFactory: PublicationFactory {
+        typealias PublicationCreated = (Publication) -> Void
+        private let callback: PublicationCreated
+
+        init(_ created: @escaping PublicationCreated) {
+            self.callback = created
+        }
+
+        func create(publication: QuicR.ManifestPublication, endpointId: String, relayId: String) throws -> [(FullTrackName, QPublishTrackHandlerObjC)] {
+            var pubs: [(FullTrackName, QPublishTrackHandlerObjC)] = []
+            for profile in publication.profileSet.profiles {
+                let ftn = try FullTrackName(namespace: profile.namespace, name: "")
+                let publication = try MockPublication(profile: profile,
+                                                      trackMode: .streamPerGroup,
+                                                      defaultPriority: 0,
+                                                      defaultTTL: 0,
+                                                      submitter: nil,
+                                                      endpointId: "",
+                                                      relayId: "")
+                self.callback(publication)
+                pubs.append((ftn, publication))
+            }
+            return pubs
+        }
+    }
+
+    class MockPublication: Publication { }
+
+    class MockSubscription: QSubscribeTrackHandlerObjC {
+        private let ftn: FullTrackName
+        init(ftn: FullTrackName) {
+            self.ftn = ftn
+            super.init(fullTrackName: self.ftn.getUnsafe())
+        }
+    }
+
+    class MockSubscriptionSet: SubscriptionSet {
+        private let subscription: ManifestSubscription
+
+        init(_ subscription: ManifestSubscription) {
+            self.subscription = subscription
+        }
+
+        func getHandlers() -> [FullTrackName: QSubscribeTrackHandlerObjC] {
+            var subs: [FullTrackName: QSubscribeTrackHandlerObjC] = [:]
+            for profile in self.subscription.profileSet.profiles {
+                let ftn = try! FullTrackName(namespace: profile.namespace, name: "")
+                subs[ftn] = MockSubscription(ftn: ftn)
+            }
+            return subs
+        }
+    }
+
+    class MockSubscriptionFactory: SubscriptionFactory {
+        func create(subscription: ManifestSubscription, endpointId: String, relayId: String) throws -> any SubscriptionSet {
+            return MockSubscriptionSet(subscription)
+        }
+    }
+
     class MockClient: MoqClient {
         typealias PublishTrackCallback = (QPublishTrackHandlerObjC) -> Void
         typealias UnpublishTrackCallback = (QPublishTrackHandlerObjC) -> Void
@@ -44,6 +103,7 @@ final class TestCallController: XCTestCase {
 
         func publishAnnounce(_ trackNamespace: Data) { }
         func publishUnannounce(_ trackNamespace: Data) {}
+        func setCallbacks(_ callbacks: any QClientCallbacks) { }
 
         func subscribeTrack(withHandler handler: QSubscribeTrackHandlerObjC) {
             self.subscribe(handler)
@@ -58,21 +118,38 @@ final class TestCallController: XCTestCase {
         }
     }
 
-    func testPublicationAdd() {
-        let publish: MockClient.PublishTrackCallback = { _ in }
+    func testPublicationAdd() async throws {
+
+        // Example publication details.
+        let details = ManifestPublication(mediaType: "video",
+                                          sourceName: "test",
+                                          sourceID: "test",
+                                          label: "Label",
+                                          profileSet: .init(type: "type",
+                                                            profiles: [
+                                                                .init(qualityProfile: "something",
+                                                                      expiry: nil,
+                                                                      priorities: nil,
+                                                                      namespace: "namespace")]))
+
+        var factoryCreated: Publication?
+        let creationCallback: MockPublicationFactory.PublicationCreated = { factoryCreated = $0 }
+
+        // Create controller.
+        var published = false
+        let publish: MockClient.PublishTrackCallback = {
+            published = $0 == factoryCreated
+        }
         let unpublished: MockClient.UnpublishTrackCallback = { _ in }
         let subscribe: MockClient.SubscribeTrackCallback = { _ in }
         let unsubscribe: MockClient.UnsubscribeTrackCallback = { _ in }
         let client = MockClient(publish: publish, unpublish: unpublished, subscribe: subscribe, unsubscribe: unsubscribe)
-        let controller = MoqCallController(endpointUri: <#T##String#>,
-                                           client: <#T##any MoqClient#>,
-                                           captureManager: <#T##CaptureManager#>,
-                                           subscriptionConfig: <#T##SubscriptionConfig#>,
-                                           engine: <#T##DecimusAudioEngine#>,
-                                           videoParticipants: <#T##VideoParticipants#>,
-                                           submitter: <#T##(any MetricsSubmitter)?#>,
-                                           granularMetrics: <#T##Bool#>,
-                                           callEnded: <#T##() -> Void#>)
+        let controller = MoqCallController(endpointUri: "1", client: client, submitter: nil) { }
+        try await controller.connect()
+
+        // Calling publish should result in a matching publication being created from the factory, and a publish track being issued on it.
+        try controller.publish(details: details, factory: MockPublicationFactory(creationCallback))
+        XCTAssert(published)
     }
 
     func testMetrics() throws {

--- a/Tests/TestCallController.swift
+++ b/Tests/TestCallController.swift
@@ -5,6 +5,76 @@ import XCTest
 @testable import QuicR
 
 final class TestCallController: XCTestCase {
+
+    class MockClient: MoqClient {
+        typealias PublishTrackCallback = (QPublishTrackHandlerObjC) -> Void
+        typealias UnpublishTrackCallback = (QPublishTrackHandlerObjC) -> Void
+        typealias SubscribeTrackCallback = (QSubscribeTrackHandlerObjC) -> Void
+        typealias UnsubscribeTrackCallback = (QSubscribeTrackHandlerObjC) -> Void
+        private let publish: PublishTrackCallback
+        private let unpublish: UnpublishTrackCallback
+        private let subscribe: SubscribeTrackCallback
+        private let unsubscribe: UnsubscribeTrackCallback
+
+        init(publish: @escaping PublishTrackCallback,
+             unpublish: @escaping UnpublishTrackCallback,
+             subscribe: @escaping SubscribeTrackCallback,
+             unsubscribe: @escaping UnsubscribeTrackCallback) {
+            self.publish = publish
+            self.unpublish = unpublish
+            self.subscribe = subscribe
+            self.unsubscribe = unsubscribe
+        }
+
+        func connect() -> QClientStatus {
+            .ready
+        }
+
+        func disconnect() -> QClientStatus {
+            .disconnecting
+        }
+
+        func publishTrack(withHandler handler: QPublishTrackHandlerObjC) {
+            self.publish(handler)
+        }
+
+        func unpublishTrack(withHandler handler: QPublishTrackHandlerObjC) {
+            self.unpublish(handler)
+        }
+
+        func publishAnnounce(_ trackNamespace: Data) { }
+        func publishUnannounce(_ trackNamespace: Data) {}
+
+        func subscribeTrack(withHandler handler: QSubscribeTrackHandlerObjC) {
+            self.subscribe(handler)
+        }
+
+        func unsubscribeTrack(withHandler handler: QSubscribeTrackHandlerObjC) {
+            self.unsubscribe(handler)
+        }
+
+        func getAnnounceStatus(_ trackNamespace: Data) -> QPublishAnnounceStatus {
+            .OK
+        }
+    }
+
+    func testPublicationAdd() {
+        let publish: MockClient.PublishTrackCallback = { _ in }
+        let unpublished: MockClient.UnpublishTrackCallback = { _ in }
+        let subscribe: MockClient.SubscribeTrackCallback = { _ in }
+        let unsubscribe: MockClient.UnsubscribeTrackCallback = { _ in }
+        let client = MockClient(publish: publish, unpublish: unpublished, subscribe: subscribe, unsubscribe: unsubscribe)
+        let controller = MoqCallController(endpointUri: <#T##String#>,
+                                           client: <#T##any MoqClient#>,
+                                           captureManager: <#T##CaptureManager#>,
+                                           subscriptionConfig: <#T##SubscriptionConfig#>,
+                                           engine: <#T##DecimusAudioEngine#>,
+                                           videoParticipants: <#T##VideoParticipants#>,
+                                           submitter: <#T##(any MetricsSubmitter)?#>,
+                                           granularMetrics: <#T##Bool#>,
+                                           callEnded: <#T##() -> Void#>)
+    }
+
     func testMetrics() throws {
         //        let config = ClientConfig(connectUri: "moq://localhost",
         //                                  endpointUri: "me",


### PR DESCRIPTION
Add new APIs to allow the client to alter the publications and subscriptions (and during call runtime). 

Also:
- Remove direct injection of the manifest in favour of using these APIs.
- Some rearchitecture to dependency injection in order to facilitate easier testing of these APIs/the call controller.  