### PR TITLE
Add initial work for active speaker handling

### DIFF
--- a/Decimus/CallController.swift
+++ b/Decimus/CallController.swift
@@ -351,4 +351,42 @@ class MoqCallController: QClientCallbacks {
             }
         }
     }
+
+    // TODO: Do we need to worry about mismatched endpoint IDs in subscription sets?
+
+    /// Get all managed subscriptions originating from the given endpoint ID.
+    /// - Parameter endpointId: The endpoint ID to query on.
+    /// - Returns: List of subscription track handlers.
+    func getSubscriptionsByEndpoint(_ endpointId: EndpointId) throws -> [QSubscribeTrackHandlerObjC] {
+        var results: [QSubscribeTrackHandlerObjC] = []
+        for set in self.subscriptions.values {
+            for handler in set.getHandlers().values {
+                let ftn = FullTrackName(handler.getFullTrackName())
+                let thisEndpointId = try ftn.getEndpointId()
+                guard thisEndpointId == endpointId else {
+                    continue
+                }
+                results.append(handler)
+            }
+        }
+        return results
+    }
+}
+
+extension FullTrackName {
+    /// Extract endpoint ID from namespace as a leading 0 padded 4 digit string.
+    func getEndpointId() throws -> Substring {
+        try self.extract(18, 21)
+    }
+
+    func getMediaType() throws -> Substring {
+        try self.extract(16, 17)
+    }
+
+    private func extract(_ start: Int, _ end: Int) throws -> Substring {
+        let namespace = try self.getNamespace()
+        let startIndex = namespace.index(namespace.startIndex, offsetBy: start)
+        let endIndex = namespace.index(namespace.startIndex, offsetBy: end)
+        return namespace[startIndex...endIndex]
+    }
 }

--- a/Decimus/Subscriptions/ActiveSpeakerNotifier.swift
+++ b/Decimus/Subscriptions/ActiveSpeakerNotifier.swift
@@ -1,0 +1,101 @@
+// SPDX-FileCopyrightText: Copyright (c) 2023 Cisco Systems
+// SPDX-License-Identifier: BSD-2-Clause
+
+/// Identifies a participant across multiple tracks or media types.
+typealias EndpointId = String
+
+/// Provides a ranked list of active speakers via callback.
+protocol ActiveSpeakerNotifier {
+    typealias ActiveSpeakersChanged = ([EndpointId]) -> Void
+    typealias CallbackToken = Int
+
+    /// Register a callback to be notified when the active speakers change.
+    /// - Parameter callback: The callback to be notified.
+    /// - Returns: A token that can be used to unregister the callback
+    func registerActiveSpeakerCallback(_ callback: @escaping ActiveSpeakersChanged) -> CallbackToken
+
+    /// Unregister a previously registered callback.
+    /// - Parameter token: The token returned by ``registerActiveSpeaker``
+    func unregisterActiveSpeakerCallback(_ token: CallbackToken)
+}
+
+/// Manages the operations associated with active speaker changes.
+class ActiveSpeakerApply {
+    private let notifier: ActiveSpeakerNotifier
+    private var callbackToken: ActiveSpeakerNotifier.CallbackToken?
+    private let controller: MoqCallController
+    private let manifest: [ManifestSubscription]
+    private let factory: SubscriptionFactory
+    private let logger = DecimusLogger(ActiveSpeakerApply.self)
+
+    /// Initialize the active speaker manager.
+    /// - Parameters:
+    ///  - notifier: Object providing active speaker updates.
+    ///  - controller: Call controller managing subscriptions.
+    ///  - subscriptions: Manifest of all available subscriptions.
+    ///  - factory: Factory for subscription handler creation.
+    init(notifier: ActiveSpeakerNotifier,
+         controller: MoqCallController,
+         subscriptions: [ManifestSubscription],
+         factory: SubscriptionFactory) {
+        self.notifier = notifier
+        self.controller = controller
+        self.manifest = subscriptions
+        self.factory = factory
+        self.callbackToken = self.notifier.registerActiveSpeakerCallback { [weak self] activeSpeakers in
+            self?.onActiveSpeakersChanged(activeSpeakers)
+        }
+    }
+
+    deinit {
+        self.notifier.unregisterActiveSpeakerCallback(self.callbackToken!)
+    }
+
+    private func onActiveSpeakersChanged(_ speakers: [EndpointId]) {
+        self.logger.debug("[ActiveSpeakers] Changed: \(speakers)")
+        let existing = self.controller.getSubscriptionSets()
+
+        // Firstly, unsubscribe from video for any speakers that are no longer active.
+        for set in existing {
+            for handler in set.getHandlers().values {
+                do {
+                    let ftn = FullTrackName(handler.getFullTrackName())
+                    let endpointId = try ftn.getEndpointId()
+                    guard !speakers.contains(where: { $0 == endpointId }),
+                          let mediaType = UInt16(try ftn.getMediaType(), radix: 16),
+                          mediaType & 0x80 != 0 else {
+                        continue
+                    }
+                    try self.logger.debug("[ActiveSpeakers] Unsubscribing from: \(ftn.getNamespace()) (\(endpointId))")
+                    try self.controller.unsubscribe(set.sourceId, ftn: ftn)
+                } catch {
+                    self.logger.warning("Error getting endpoint ID: \(error)")
+                }
+            }
+        }
+
+        // Now, subscribe to video from any speakers we are not already subscribed to.
+        for speaker in speakers {
+            for set in self.manifest {
+                for subscription in set.profileSet.profiles {
+                    do {
+                        // If this subscription is in existing, skip it.
+                        let existingSources = existing.map { $0.sourceId }
+                        let ftn = try FullTrackName(namespace: subscription.namespace, name: "")
+                        guard !existingSources.contains(set.sourceID),
+                              let mediaType = UInt16(try ftn.getMediaType(), radix: 16),
+                              mediaType & 0x80 != 0 else {
+                            continue
+                        }
+                        let endpointId = try ftn.getEndpointId()
+                        guard endpointId == speaker else { continue }
+                        self.logger.debug("[ActiveSpeakers] Subscribing to: \(subscription.namespace) (\(endpointId))")
+                        try self.controller.subscribeToSet(details: set, factory: self.factory)
+                    } catch {
+                        self.logger.error("Failed to subscribe: \(subscription.namespace)")
+                    }
+                }
+            }
+        }
+    }
+}

--- a/QuicR.xcodeproj/project.pbxproj
+++ b/QuicR.xcodeproj/project.pbxproj
@@ -105,6 +105,8 @@
 		9BDD5B182996A86500C01D54 /* LibOpusDecoder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9BDD5B172996A86500C01D54 /* LibOpusDecoder.swift */; };
 		9BDD5B1A299A395B00C01D54 /* LibOpusEncoder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9BDD5B19299A395B00C01D54 /* LibOpusEncoder.swift */; };
 		9BDE868B2B70ECC6009467A7 /* SwiftInterop.m in Sources */ = {isa = PBXBuildFile; fileRef = 9BDE868A2B70ECC6009467A7 /* SwiftInterop.m */; };
+		9BE6288A2CE366AE001401D0 /* ActiveSpeakerNotifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9BE628892CE366A9001401D0 /* ActiveSpeakerNotifier.swift */; };
+		9BE6288C2CE36A32001401D0 /* TestActiveSpeaker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9BE6288B2CE36A30001401D0 /* TestActiveSpeaker.swift */; };
 		9BE6B7C72C9D92940069FE9F /* TokenStorage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9BE6B7C62C9D92890069FE9F /* TokenStorage.swift */; };
 		9BE6B7C92C9D92C20069FE9F /* TestTokenStorage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9BE6B7C82C9D92BF0069FE9F /* TestTokenStorage.swift */; };
 		9BEC9D9A2B860DB800768EB6 /* ApplicationSEIs.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9BEC9D992B860DB800768EB6 /* ApplicationSEIs.swift */; };
@@ -299,6 +301,8 @@
 		9BDD5B19299A395B00C01D54 /* LibOpusEncoder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LibOpusEncoder.swift; sourceTree = "<group>"; };
 		9BDE868A2B70ECC6009467A7 /* SwiftInterop.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SwiftInterop.m; sourceTree = "<group>"; };
 		9BDE868C2B70ED0E009467A7 /* SwiftInterop.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SwiftInterop.h; sourceTree = "<group>"; };
+		9BE628892CE366A9001401D0 /* ActiveSpeakerNotifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActiveSpeakerNotifier.swift; sourceTree = "<group>"; };
+		9BE6288B2CE36A30001401D0 /* TestActiveSpeaker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestActiveSpeaker.swift; sourceTree = "<group>"; };
 		9BE6B7C62C9D92890069FE9F /* TokenStorage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TokenStorage.swift; sourceTree = "<group>"; };
 		9BE6B7C82C9D92BF0069FE9F /* TestTokenStorage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestTokenStorage.swift; sourceTree = "<group>"; };
 		9BEC9D992B860DB800768EB6 /* ApplicationSEIs.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApplicationSEIs.swift; sourceTree = "<group>"; };
@@ -469,6 +473,7 @@
 		9B85951C29F04521008C813C /* Tests */ = {
 			isa = PBXGroup;
 			children = (
+				9BE6288B2CE36A30001401D0 /* TestActiveSpeaker.swift */,
 				9BE6B7C82C9D92BF0069FE9F /* TestTokenStorage.swift */,
 				187DE3722C997D290090FB68 /* TestOpusSubscription.swift */,
 				187DE3702C997C770090FB68 /* TestVideoSubscription.swift */,
@@ -651,6 +656,7 @@
 		FF2498B52A55E8F800C6D66D /* Subscriptions */ = {
 			isa = PBXGroup;
 			children = (
+				9BE628892CE366A9001401D0 /* ActiveSpeakerNotifier.swift */,
 				184912872A3A51FC00773D39 /* OpusSubscription.swift */,
 				FF2498B62A55E95E00C6D66D /* VideoSubscriptionSet.swift */,
 				FF2498B32A55E8CC00C6D66D /* SubscriptionFactory.swift */,
@@ -933,6 +939,7 @@
 				187DE3712C997C7A0090FB68 /* TestVideoSubscription.swift in Sources */,
 				9B7F40042ACB5808003333C3 /* TestVideoUtilities.swift in Sources */,
 				9BC53C9A2BFDEC7800BB39C6 /* TestVideoPublication.swift in Sources */,
+				9BE6288C2CE36A32001401D0 /* TestActiveSpeaker.swift in Sources */,
 				9B0E0F1C2C4A9A0300F06D6E /* TestNumberView.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -950,6 +957,7 @@
 				9BD96EFD2AC2DAA200EC794C /* VideoJitterBufferSettingsView.swift in Sources */,
 				9B9622DC2A7A669A00949234 /* QHelpers.swift in Sources */,
 				9B48068C298301FD0040F5D4 /* QMediaTypes.swift in Sources */,
+				9BE6288A2CE366AE001401D0 /* ActiveSpeakerNotifier.swift in Sources */,
 				FFFF72D72A27D47D00D4D5EE /* ErrorView.swift in Sources */,
 				184912882A3A51FC00773D39 /* OpusSubscription.swift in Sources */,
 				9B87FB622A03B91E00C92DD1 /* SettingsView.swift in Sources */,

--- a/Tests/TestActiveSpeaker.swift
+++ b/Tests/TestActiveSpeaker.swift
@@ -1,0 +1,132 @@
+// SPDX-FileCopyrightText: Copyright (c) 2023 Cisco Systems
+// SPDX-License-Identifier: BSD-2-Clause
+
+import XCTest
+@testable import QuicR
+
+final class TestActiveSpeaker: XCTestCase {
+    class MockActiveSpeakerNotifier: ActiveSpeakerNotifier {
+        private var callbacks: [CallbackToken: ActiveSpeakersChanged] = [:]
+        private var token: CallbackToken = 0
+
+        func fire(_ activeSpeakers: [EndpointId]) {
+            for callback in self.callbacks.values {
+                callback(activeSpeakers)
+            }
+        }
+
+        func registerActiveSpeakerCallback(_ callback: @escaping ActiveSpeakersChanged) -> CallbackToken {
+            let token = self.token
+            self.token += 1
+            self.callbacks[token] = callback
+            return token
+        }
+
+        func unregisterActiveSpeakerCallback(_ token: CallbackToken) {
+            self.callbacks.removeValue(forKey: token)
+        }
+    }
+
+    func testActiveSpeaker() async throws {
+        // Given a list of active speakers, the controller's subscriptions should change
+        // to reflect the list.
+
+        // Prepare the manifest.
+        func makeVideoNamespace(_ endpointId: Int) -> String {
+            "0x000001010003F2A0000\(endpointId)000000000000/80"
+        }
+        let manifestSubscription1 = ManifestSubscription(mediaType: "1",
+                                                         sourceName: "1",
+                                                         sourceID: "1",
+                                                         label: "1",
+                                                         profileSet: .init(type: "1", profiles: [
+                                                            .init(qualityProfile: "1",
+                                                                  expiry: nil,
+                                                                  priorities: nil,
+                                                                  namespace: makeVideoNamespace(1))
+                                                         ]))
+        let manifestSubscription2 = ManifestSubscription(mediaType: "2",
+                                                         sourceName: "2",
+                                                         sourceID: "2",
+                                                         label: "2",
+                                                         profileSet: .init(type: "2", profiles: [
+                                                            .init(qualityProfile: "2",
+                                                                  expiry: nil,
+                                                                  priorities: nil,
+                                                                  namespace: makeVideoNamespace(2))
+                                                         ]))
+        let manifestSubscription3 = ManifestSubscription(mediaType: "3",
+                                                         sourceName: "3",
+                                                         sourceID: "3",
+                                                         label: "3",
+                                                         profileSet: .init(type: "3", profiles: [
+                                                            .init(qualityProfile: "3",
+                                                                  expiry: nil,
+                                                                  priorities: nil,
+                                                                  namespace: makeVideoNamespace(3))
+                                                         ]))
+        let manifestSubscriptions = [manifestSubscription1, manifestSubscription2, manifestSubscription3]
+
+        var subbed: [QSubscribeTrackHandlerObjC] = []
+        var unsubbed: [QSubscribeTrackHandlerObjC] = []
+        let sub: TestCallController.MockClient.SubscribeTrackCallback = { subbed.append($0) }
+        let unsub: TestCallController.MockClient.SubscribeTrackCallback = { unsubbed.append($0) }
+
+        let client = TestCallController.MockClient(publish: { _ in }, unpublish: { _ in }, subscribe: sub, unsubscribe: unsub)
+        let controller = MoqCallController(endpointUri: "4", client: client, submitter: nil) { }
+        try await controller.connect()
+
+        // Subscribe to 1 and 2.
+        try controller.subscribeToSet(details: manifestSubscription1, factory: TestCallController.MockSubscriptionFactory({
+            XCTAssertEqual($0.sourceId, manifestSubscription1.sourceID)
+        }))
+        try controller.subscribeToSet(details: manifestSubscription2, factory: TestCallController.MockSubscriptionFactory({
+            XCTAssertEqual($0.sourceId, manifestSubscription2.sourceID)
+        }))
+
+        // 1 and 2 should be created and subscribed to.
+        let initialSubscriptionSets = controller.getSubscriptionSets()
+        XCTAssertEqual(initialSubscriptionSets.map { $0.sourceId }.sorted(), [manifestSubscription1, manifestSubscription2].map { $0.sourceID }.sorted())
+        let handlers = initialSubscriptionSets.reduce(into: []) { $0.append(contentsOf: $1.getHandlers().values) }
+        XCTAssertEqual(try handlers.sorted(by: {
+            try FullTrackName($0.getFullTrackName()).getNamespace() < FullTrackName($1.getFullTrackName()).getNamespace()
+        }), subbed)
+
+        // Now, 1 and 3 are actively speaking.
+        subbed = []
+        unsubbed = []
+        let speakerOne: EndpointId = "0001"
+        let speakerTwo: EndpointId = "0002"
+        let speakerThree: EndpointId = "0003"
+        let newSpeakers: [EndpointId] = [speakerOne, speakerThree]
+        let notifier = MockActiveSpeakerNotifier()
+        var created: [SubscriptionSet] = []
+        let factory = TestCallController.MockSubscriptionFactory { created.append($0) }
+        let activeSpeakerController = ActiveSpeakerApply(notifier: notifier,
+                                                         controller: controller,
+                                                         subscriptions: manifestSubscriptions,
+                                                         factory: factory)
+
+        // Test state clear.
+        XCTAssert(created.isEmpty)
+        XCTAssert(subbed.isEmpty)
+        XCTAssert(unsubbed.isEmpty)
+
+        // Mock active speaker change.
+        notifier.fire(newSpeakers)
+
+        // Factory should have created subscription 3.
+        XCTAssertEqual(created.map { $0.sourceId }.sorted(), [manifestSubscription3].map { $0.sourceID }.sorted())
+        // Controller should have subscribed to 3.
+        XCTAssert(try subbed.reduce(into: true, {
+            try $0 = $0 && FullTrackName($1.getFullTrackName()).getEndpointId() == speakerThree
+        }))
+        // Should have unsubscribed from 2.
+        XCTAssert(try unsubbed.reduce(into: true, {
+            try $0 = $0 && FullTrackName($1.getFullTrackName()).getEndpointId() == speakerTwo
+        }))
+        // 1 should still be present.
+        let active = try controller.getSubscriptionsByEndpoint(speakerOne)
+        XCTAssert(active.count == 1)
+    }
+}


### PR DESCRIPTION
Initial work & tests for handling an active speaker change. An `ActiveSpeakerNotifier` can call back a changed list of participants. `ActiveSpeakerApply` receives this list, and subscribes to video media from speakers that is not currently subscribed to, and unsubscribes from any currently subscribed media that is not speaking. 