### PR TITLE
New video layouts

### DIFF
--- a/Decimus/Views/Components/VideoGrid.swift
+++ b/Decimus/Views/Components/VideoGrid.swift
@@ -19,11 +19,13 @@ struct VideoGrid: View {
     }
 
     private func calcColumns() -> CGFloat {
-        return .init(min(maxColumns, max(1, Int(ceil(sqrt(Double(participants.count)))))))
+        let denom = self.restrictedCount != nil ? self.restrictedCount! : self.participants.count
+        return .init(min(maxColumns, max(1, Int(ceil(sqrt(Double(denom)))))))
     }
 
     private func calcRows(_ columns: CGFloat) -> CGFloat {
-        return .init(round(Float(participants.count) / Float(columns)))
+        let numerator = self.restrictedCount != nil ? self.restrictedCount! : self.participants.count
+        return .init(round(Float(numerator) / Float(columns)))
     }
 
     var body: some View {

--- a/Decimus/Views/Settings/PlaytimeSettingsView.swift
+++ b/Decimus/Views/Settings/PlaytimeSettingsView.swift
@@ -5,7 +5,6 @@ import SwiftUI
 
 struct PlaytimeSettings: Codable {
     var playtime = false
-    var restrictedGridCount = 4
 }
 
 struct PlaytimeSettingsView: View {
@@ -19,11 +18,6 @@ struct PlaytimeSettingsView: View {
             LabeledToggle("Playtime", isOn: self.$playtimeConfig.value.playtime)
             if self.playtimeConfig.value.playtime {
                 Form {
-                    LabeledContent("Grid View Max") {
-                        NumberView(value: self.$playtimeConfig.value.restrictedGridCount,
-                                   formatStyle: IntegerFormatStyle<Int>.number.grouping(.never),
-                                   name: "Grid View Max")
-                    }
                 }
                 .formStyle(.columns)
             }


### PR DESCRIPTION
- Adds options for a 1x1, 2x2 and unlimited (NxN, today's behaviour) grid layout, changeable during a call.
- Removes grid count config in favour of these options.
- Film strip layout currently not implemented. 