### PR TITLE
Add default Subscription implementation

### DIFF
--- a/Config.xcconfig
+++ b/Config.xcconfig
@@ -4,4 +4,4 @@
 // Configuration settings file format documentation can be found at:
 // https://help.apple.com/xcode/#/dev745c5c974
 
-APP_VERSION=2.7.1
+APP_VERSION=2.8.0

--- a/Decimus/Subscriptions/CallbackSubscription.swift
+++ b/Decimus/Subscriptions/CallbackSubscription.swift
@@ -2,37 +2,29 @@
 // SPDX-License-Identifier: BSD-2-Clause
 
 /// A subscription that provides received objects via a callback.
-class CallbackSubscription: QSubscribeTrackHandlerObjC, QSubscribeTrackHandlerCallbacks {
+class CallbackSubscription: Subscription {
     typealias SubscriptionCallback = (QObjectHeaders, Data, [NSNumber: Data]?) -> Void
-    private let logger = DecimusLogger(CallbackSubscription.self)
     private let callback: SubscriptionCallback
 
-    init(fullTrackName: FullTrackName,
+    init(profile: Profile,
+         endpointId: String,
+         relayId: String,
+         metricsSubmitter: MetricsSubmitter?,
          priority: UInt8,
          groupOrder: QGroupOrder,
          filterType: QFilterType,
-         callback: @escaping SubscriptionCallback) {
+         callback: @escaping SubscriptionCallback) throws {
         self.callback = callback
-        super.init(fullTrackName: fullTrackName,
-                   priority: priority,
-                   groupOrder: groupOrder,
-                   filterType: filterType)
-        super.setCallbacks(self)
+        try super.init(profile: profile,
+                       endpointId: endpointId,
+                       relayId: relayId,
+                       metricsSubmitter: metricsSubmitter,
+                       priority: priority,
+                       groupOrder: groupOrder,
+                       filterType: filterType)
     }
 
-    func statusChanged(_ status: QSubscribeTrackHandlerStatus) {
-        self.logger.info("Status changed: \(status)")
-    }
-
-    func objectReceived(_ objectHeaders: QObjectHeaders, data: Data, extensions: [NSNumber: Data]?) {
+    override func objectReceived(_ objectHeaders: QObjectHeaders, data: Data, extensions: [NSNumber: Data]?) {
         self.callback(objectHeaders, data, extensions)
-    }
-
-    func partialObjectReceived(_ objectHeaders: QObjectHeaders, data: Data, extensions: [NSNumber: Data]?) {
-        self.logger.warning("Unexpected partial object received")
-    }
-
-    func metricsSampled(_ metrics: QSubscribeTrackMetrics) {
-        // TODO: Record metrics.
     }
 }

--- a/Decimus/Subscriptions/Subscription.swift
+++ b/Decimus/Subscriptions/Subscription.swift
@@ -1,0 +1,71 @@
+// SPDX-FileCopyrightText: Copyright (c) 2023 Cisco Systems
+// SPDX-License-Identifier: BSD-2-Clause
+
+/// Base implementation for a track handler, handling generic metrics and callbacks.
+class Subscription: QSubscribeTrackHandlerObjC, QSubscribeTrackHandlerCallbacks {
+    private let quicrMeasurement: MeasurementRegistration<TrackMeasurement>?
+    private let logger = DecimusLogger(Subscription.self)
+
+    /// Create a new subscription for the given profile.
+    /// - Parameters:
+    ///   - profile: Details of the track to subscribe to.
+    ///   - endpointId: Metrics identifier.
+    ///   - relayId: Metrics identifier.
+    ///   - metricsSubmitter: Optionally, submitter for metrics.
+    ///   - priority: Priority for the subscription.
+    ///   - groupOrder: Subscription for group order.
+    ///   - filterType: Filter type.
+    init(profile: Profile,
+         endpointId: String,
+         relayId: String,
+         metricsSubmitter: MetricsSubmitter?,
+         priority: UInt8,
+         groupOrder: QGroupOrder,
+         filterType: QFilterType) throws {
+        if let submitter = metricsSubmitter {
+            self.quicrMeasurement = .init(measurement: .init(type: .subscribe,
+                                                             endpointId: endpointId,
+                                                             relayId: relayId,
+                                                             namespace: profile.namespace.joined()),
+                                          submitter: submitter)
+        } else {
+            self.quicrMeasurement = nil
+        }
+        super.init(fullTrackName: try profile.getFullTrackName(),
+                   priority: priority,
+                   groupOrder: groupOrder,
+                   filterType: filterType)
+        super.setCallbacks(self)
+    }
+
+    /// Fires when the underlying subscription handler's status changes.
+    /// - Parameter status: The updated status.
+    func statusChanged(_ status: QSubscribeTrackHandlerStatus) {
+        self.logger.debug("Status changed: \(status)")
+    }
+
+    /// Fires when a full object has been received.
+    /// - Parameters:
+    ///   - objectHeaders: The headers for this object.
+    ///   - data: Object payload bytes.
+    ///   - extensions: Header extensions, if any.
+    func objectReceived(_ objectHeaders: QObjectHeaders, data: Data, extensions: [NSNumber: Data]?) {}
+
+    /// Fires when a partial object has been received.
+    /// - Parameters:
+    ///   - objectHeaders: The headers for this object.
+    ///   - data: Object payload bytes.
+    ///   - extensions: Header extensions, if any.
+    func partialObjectReceived(_ objectHeaders: QObjectHeaders, data: Data, extensions: [NSNumber: Data]?) {}
+
+    /// Fires when the underlying handler produces metrics.
+    /// The default implementation submits these metrics through the provided submitter, if any.
+    /// - Parameter metrics: The produced track metrics.
+    func metricsSampled(_ metrics: QSubscribeTrackMetrics) {
+        if let quicrMeasurement = self.quicrMeasurement {
+            Task(priority: .utility) {
+                await quicrMeasurement.measurement.record(metrics)
+            }
+        }
+    }
+}

--- a/QuicR.xcodeproj/project.pbxproj
+++ b/QuicR.xcodeproj/project.pbxproj
@@ -95,6 +95,7 @@
 		9BAD55BD29B0B77700D9B65F /* ErrorWriter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9BAD55BC29B0B77700D9B65F /* ErrorWriter.swift */; };
 		9BB0C7F82C871A6D005899B9 /* LowOverheadContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9BB0C7F72C871A6D005899B9 /* LowOverheadContainer.swift */; };
 		9BB0F71A2C29CAB500253A82 /* TestMeasurementRegistration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9BB0F7192C29CAB500253A82 /* TestMeasurementRegistration.swift */; };
+		9BC070D52D2D3A8B00FE5B0E /* Subscription.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9BC070D42D2D3A8700FE5B0E /* Subscription.swift */; };
 		9BC53C9A2BFDEC7800BB39C6 /* TestVideoPublication.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9BC53C992BFDEC7800BB39C6 /* TestVideoPublication.swift */; };
 		9BC53C9C2BFE075300BB39C6 /* VarianceCalculator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9BC53C9B2BFE075300BB39C6 /* VarianceCalculator.swift */; };
 		9BC53C9E2BFE0AA000BB39C6 /* VarianceCalculator+Measurement.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9BC53C9D2BFE0AA000BB39C6 /* VarianceCalculator+Measurement.swift */; };
@@ -295,6 +296,7 @@
 		9BAD55BC29B0B77700D9B65F /* ErrorWriter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ErrorWriter.swift; sourceTree = "<group>"; };
 		9BB0C7F72C871A6D005899B9 /* LowOverheadContainer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LowOverheadContainer.swift; sourceTree = "<group>"; };
 		9BB0F7192C29CAB500253A82 /* TestMeasurementRegistration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestMeasurementRegistration.swift; sourceTree = "<group>"; };
+		9BC070D42D2D3A8700FE5B0E /* Subscription.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Subscription.swift; sourceTree = "<group>"; };
 		9BC53C992BFDEC7800BB39C6 /* TestVideoPublication.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestVideoPublication.swift; sourceTree = "<group>"; };
 		9BC53C9B2BFE075300BB39C6 /* VarianceCalculator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VarianceCalculator.swift; sourceTree = "<group>"; };
 		9BC53C9D2BFE0AA000BB39C6 /* VarianceCalculator+Measurement.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "VarianceCalculator+Measurement.swift"; sourceTree = "<group>"; };
@@ -670,6 +672,7 @@
 		FF2498B52A55E8F800C6D66D /* Subscriptions */ = {
 			isa = PBXGroup;
 			children = (
+				9BC070D42D2D3A8700FE5B0E /* Subscription.swift */,
 				9B807A692CF6015B007C7E6E /* ActiveSpeakerNotifierSubscriptionSet.swift */,
 				9B807A672CF5FFCD007C7E6E /* CallbackSubscription.swift */,
 				9B807A652CF5FF6D007C7E6E /* ActiveSpeakerSubscriptionSet.swift */,
@@ -1042,6 +1045,7 @@
 				186763572B2B6B1100339421 /* CaptureManager+Measurement.swift in Sources */,
 				FFB8CBE529C148B70093C623 /* ActionPicker.swift in Sources */,
 				D7D156392AD73DE600B4E4F2 /* EncodedFrameBufferAllocator.mm in Sources */,
+				9BC070D52D2D3A8B00FE5B0E /* Subscription.swift in Sources */,
 				18EC340D2A69CFD6004FE2EE /* VideoView.swift in Sources */,
 				9BEC9D9A2B860DB800768EB6 /* ApplicationSEIs.swift in Sources */,
 				FF2498B02A534E8E00C6D66D /* H264Publication.swift in Sources */,


### PR DESCRIPTION
Adds a Swift `Subscription` class for the base of all subscriptions, providing the standard setup and wiring of `QSubscribeTrackHandlerObjC` with `QSubscribeTrackHandlerCallbacks`, reporting status changes, and metrics. 