### PR TITLE
Manage own participant

### DIFF
--- a/Config.xcconfig
+++ b/Config.xcconfig
@@ -4,4 +4,4 @@
 // Configuration settings file format documentation can be found at:
 // https://help.apple.com/xcode/#/dev745c5c974
 
-APP_VERSION=2.8.0
+APP_VERSION=2.8.1

--- a/Decimus/Models/VideoParticipant.swift
+++ b/Decimus/Models/VideoParticipant.swift
@@ -37,23 +37,20 @@ class VideoParticipants: ObservableObject {
     private var cancellables: [SourceIDType: AnyCancellable] = [:]
     private let startDate = Date.now
 
-    /// Get or create a ``VideoParticipant``.
-    /// - Parameter identifier: The identifier for the target view.
-    /// - Returns: The created video view.
-    func getOrMake(identifier: SourceIDType, subscribeDate: Date) -> VideoParticipant {
-        if let participant = participants[identifier] {
-            return participant
+    /// Add a participant.
+    /// - Parameter videoParticipant: The participant to add.
+    /// - Throws: If the participant already exists.
+    func add(_ videoParticipant: VideoParticipant) throws {
+        if self.participants[videoParticipant.id] != nil {
+            throw "Already Exists"
         }
-
-        let new: VideoParticipant = .init(id: identifier, startDate: self.startDate, subscribeDate: subscribeDate)
-        let cancellable = new.objectWillChange.sink(receiveValue: {
+        let cancellable = videoParticipant.objectWillChange.sink(receiveValue: {
             DispatchQueue.main.async {
                 self.objectWillChange.send()
             }
         })
-        cancellables[identifier] = cancellable
-        participants[identifier] = new
-        return new
+        self.cancellables[videoParticipant.id] = cancellable
+        self.participants[videoParticipant.id] = videoParticipant
     }
 
     /// Remove a participant view.

--- a/Decimus/Models/VideoParticipant.swift
+++ b/Decimus/Models/VideoParticipant.swift
@@ -1,71 +1,89 @@
 // SPDX-FileCopyrightText: Copyright (c) 2023 Cisco Systems
 // SPDX-License-Identifier: BSD-2-Clause
 
-import Combine
-
 enum ParticipantError: Error {
+    case alreadyExists
     case notFound
 }
 
 /// Represents a visible video display.
-class VideoParticipant: ObservableObject, Identifiable {
+@Observable
+@MainActor
+class VideoParticipant: Identifiable {
     /// The identifier for this participant (either a namespace, or a source ID for an aggregate).
-    var id: SourceIDType
+    let id: SourceIDType
     /// The SwiftUI view for video display.
     var view: VideoView
     /// The label to display under the video.
-    @Published var label: String
+    var label: String
     /// True if this video should be highlighted.
-    @Published var highlight: Bool
+    var highlight: Bool
+    private let videoParticipants: VideoParticipants
+    private let logger = DecimusLogger(VideoParticipant.self)
 
     /// Create a new participant for the given identifier.
     /// - Parameter id: Namespace or source ID.
-    init(id: SourceIDType, startDate: Date, subscribeDate: Date) {
+    /// - Parameter startDate: Join date of the call, for statistics.
+    /// - Parameter subscribeDate: Subscribe date of the call, for statistics.
+    /// - Parameter videoParticipants: The holder to register against.
+    init(id: SourceIDType, startDate: Date, subscribeDate: Date, videoParticipants: VideoParticipants) throws {
         self.id = id
         self.label = id
         self.highlight = false
         self.view = VideoView(startDate: startDate, subscribeDate: subscribeDate)
+        self.videoParticipants = videoParticipants
+        try self.videoParticipants.add(self)
+    }
+
+    deinit {
+        self.logger.debug("[\(self.id)] Deinit")
+        Task { [id, videoParticipants, logger] in
+            await MainActor.run {
+                do {
+                    try videoParticipants.removeParticipant(identifier: id)
+                } catch {
+                    logger.warning("[\(id)] Failed to remove participant")
+                }
+            }
+        }
     }
 }
 
 /// Holder for all video participants.
-class VideoParticipants: ObservableObject {
+@Observable
+@MainActor
+class VideoParticipants {
+    class Weak<T: AnyObject>: Identifiable {
+        weak var value: T?
+        init(_ value: T) {
+            self.value = value
+        }
+    }
+
     private static let logger = DecimusLogger(VideoParticipants.self)
 
     /// All tracked participants by identifier.
-    @Published var participants: [SourceIDType: VideoParticipant] = [:]
-    private var cancellables: [SourceIDType: AnyCancellable] = [:]
-    private let startDate = Date.now
+    private var weakParticipants: [SourceIDType: Weak<VideoParticipant>] = [:]
+    var participants: [Weak<VideoParticipant>] { Array(self.weakParticipants.values) }
 
     /// Add a participant.
     /// - Parameter videoParticipant: The participant to add.
-    /// - Throws: If the participant already exists.
-    func add(_ videoParticipant: VideoParticipant) throws {
-        if self.participants[videoParticipant.id] != nil {
-            throw "Already Exists"
+    /// - Throws: ``ParticipantError.alreadyExists`` if the participant has already been added.
+    fileprivate func add(_ videoParticipant: VideoParticipant) throws {
+        if self.weakParticipants[videoParticipant.id] != nil {
+            throw ParticipantError.alreadyExists
         }
-        let cancellable = videoParticipant.objectWillChange.sink(receiveValue: {
-            DispatchQueue.main.async {
-                self.objectWillChange.send()
-            }
-        })
-        self.cancellables[videoParticipant.id] = cancellable
-        self.participants[videoParticipant.id] = videoParticipant
+        self.weakParticipants[videoParticipant.id] = .init(videoParticipant)
+        Self.logger.debug("[\(videoParticipant.id)] Added participant")
     }
 
     /// Remove a participant view.
     /// - Parameter identifier: The identifier for the target view to remove.
-    func removeParticipant(identifier: SourceIDType) {
-        DispatchQueue.main.async {
-            guard let removed = self.participants.removeValue(forKey: identifier) else {
-                return
-            }
-            removed.objectWillChange.send()
-            let cancellable = self.cancellables[identifier]
-            cancellable!.cancel()
-            self.cancellables.removeValue(forKey: identifier)
-            self.objectWillChange.send()
-            Self.logger.info("[\(identifier)] Removed participant")
+    /// - Throws: ``ParticipantError.notFound`` if the participant is not found.
+    fileprivate func removeParticipant(identifier: SourceIDType) throws {
+        guard self.weakParticipants.removeValue(forKey: identifier) != nil else {
+            throw ParticipantError.notFound
         }
+        Self.logger.debug("[\(identifier)] Removed participant")
     }
 }

--- a/Decimus/Subscriptions/SubscriptionFactory.swift
+++ b/Decimus/Subscriptions/SubscriptionFactory.swift
@@ -145,6 +145,7 @@ class SubscriptionFactoryImpl: SubscriptionFactory {
     private let granularMetrics: Bool
     private let engine: DecimusAudioEngine
     private let participantId: ParticipantId?
+    private let joinDate: Date
     var activeSpeakerNotifier: ActiveSpeakerNotifierSubscriptionSet?
 
     init(videoParticipants: VideoParticipants,
@@ -152,13 +153,15 @@ class SubscriptionFactoryImpl: SubscriptionFactory {
          subscriptionConfig: SubscriptionConfig,
          granularMetrics: Bool,
          engine: DecimusAudioEngine,
-         participantId: ParticipantId?) {
+         participantId: ParticipantId?,
+         joinDate: Date) {
         self.videoParticipants = videoParticipants
         self.metricsSubmitter = metricsSubmitter
         self.subscriptionConfig = subscriptionConfig
         self.granularMetrics = granularMetrics
         self.engine = engine
         self.participantId = participantId
+        self.joinDate = joinDate
     }
 
     func create(subscription: ManifestSubscription,
@@ -216,7 +219,8 @@ class SubscriptionFactoryImpl: SubscriptionFactory {
                                             pauseResume: self.subscriptionConfig.pauseResume,
                                             endpointId: endpointId,
                                             relayId: relayId,
-                                            codecFactory: CodecFactoryImpl())
+                                            codecFactory: CodecFactoryImpl(),
+                                            joinDate: self.joinDate)
         }
 
         if found.isSubset(of: opusCodecs) {
@@ -276,6 +280,7 @@ class SubscriptionFactoryImpl: SubscriptionFactory {
                                          endpointId: endpointId,
                                          relayId: relayId,
                                          participantId: set.participantId,
+                                         joinDate: self.joinDate,
                                          callback: { [weak set] timestamp, when in
                                             guard let set = set else { return }
                                             set.receivedObject(ftn, timestamp: timestamp, when: when)

--- a/Decimus/Subscriptions/VideoSubscription.swift
+++ b/Decimus/Subscriptions/VideoSubscription.swift
@@ -31,7 +31,8 @@ class VideoSubscription: Subscription {
     private let cleanupTimer: TimeInterval = 1.5
     private var lastUpdateTime = Date.now
     private let participantId: ParticipantId
-    private let creationTime: Date
+    private let creationDate: Date
+    private let joinDate: Date
 
     init(profile: Profile,
          config: VideoCodecConfig,
@@ -46,6 +47,7 @@ class VideoSubscription: Subscription {
          endpointId: String,
          relayId: String,
          participantId: ParticipantId,
+         joinDate: Date,
          callback: @escaping ObjectReceived,
          statusChanged: @escaping StatusChanged) throws {
         self.fullTrackName = try profile.getFullTrackName()
@@ -61,8 +63,8 @@ class VideoSubscription: Subscription {
         self.callback = callback
         self.statusChangeCallback = statusChanged
         self.participantId = participantId
-
-        self.creationTime = .now
+        self.creationDate = .now
+        self.joinDate = joinDate
         let handler = try VideoHandler(fullTrackName: fullTrackName,
                                        config: config,
                                        participants: participants,
@@ -74,7 +76,8 @@ class VideoSubscription: Subscription {
                                        simulreceive: simulreceive,
                                        variances: variances,
                                        participantId: participantId,
-                                       subscribeDate: self.creationTime)
+                                       subscribeDate: self.creationDate,
+                                       joinDate: joinDate)
         self.token = handler.registerCallback(callback)
         self.handler = handler
         try super.init(profile: profile,
@@ -158,7 +161,8 @@ class VideoSubscription: Subscription {
                                              simulreceive: self.simulreceive,
                                              variances: self.variances,
                                              participantId: self.participantId,
-                                             subscribeDate: self.creationTime)
+                                             subscribeDate: self.creationDate,
+                                             joinDate: self.joinDate)
             self.token = recreated.registerCallback(self.callback)
             self.handler = recreated
             handler = recreated

--- a/Decimus/Subscriptions/VideoSubscriptionSet.swift
+++ b/Decimus/Subscriptions/VideoSubscriptionSet.swift
@@ -234,9 +234,19 @@ class VideoSubscriptionSet: SubscriptionSet {
             }
         }
 
-        // If we're responsible for rendering, start the task.
-        if self.simulreceive != .none && (self.renderTask == nil || self.renderTask!.isCancelled) {
-            startRenderTask()
+        // If we're responsible for rendering.
+        if self.simulreceive != .none {
+            // Start the render task.
+            if self.renderTask == nil || self.renderTask!.isCancelled {
+                self.startRenderTask()
+            }
+
+            if self.simulreceive == .enable {
+                // Ensure the participant is added.
+                if self.simulreceive == .enable {
+                    try? self.participants.add(self.participant!)
+                }
+            }
         }
 
         // Record the last time this updated.

--- a/Decimus/Views/Components/VideoGrid.swift
+++ b/Decimus/Views/Components/VideoGrid.swift
@@ -14,7 +14,13 @@ struct VideoGrid: View {
     @Binding var blur: Bool
     let restrictedCount: Int?
     @State var videoParticipants: VideoParticipants
-    private var participants: [VideoParticipants.Weak<VideoParticipant>] { self.videoParticipants.participants }
+    private var participants: [VideoParticipants.Weak<VideoParticipant>] {
+        if let restrictedCount = self.restrictedCount {
+            return Array(self.videoParticipants.participants.prefix(restrictedCount))
+        } else {
+            return Array(self.videoParticipants.participants)
+        }
+    }
 
     private func calcColumns() -> CGFloat {
         let denom: Int

--- a/Decimus/Views/InCallView.swift
+++ b/Decimus/Views/InCallView.swift
@@ -286,6 +286,7 @@ extension InCallView {
         var relayId: String?
         private(set) var publicationFactory: PublicationFactory?
         private(set) var subscriptionFactory: SubscriptionFactoryImpl?
+        private let joinDate = Date.now
 
         @AppStorage(SubscriptionSettingsView.showLabelsKey)
         var showLabels: Bool = true
@@ -363,7 +364,8 @@ extension InCallView {
                                                               subscriptionConfig: self.subscriptionConfig.value,
                                                               granularMetrics: self.influxConfig.value.granular,
                                                               engine: engine,
-                                                              participantId: ourParticipantId)
+                                                              participantId: ourParticipantId,
+                                                              joinDate: self.joinDate)
             self.publicationFactory = publicationFactory
             self.subscriptionFactory = subscriptionFactory
             let controller = self.makeCallController()

--- a/Tests/TestVideoSubscription.swift
+++ b/Tests/TestVideoSubscription.swift
@@ -22,6 +22,7 @@ final class TestVideoSubscription: XCTestCase {
                                                  endpointId: "",
                                                  relayId: "",
                                                  participantId: .init(1),
+                                                 joinDate: .now,
                                                  callback: ({ _, _ in }),
                                                  statusChanged: ({_ in }))
         subscription.metricsSampled(.init())

--- a/Tests/TestVideoSubscription.swift
+++ b/Tests/TestVideoSubscription.swift
@@ -5,7 +5,8 @@ import XCTest
 @testable import QuicR
 
 final class TestVideoSubscription: XCTestCase {
-    func testMetrics() throws {
+    @MainActor
+    func testMetrics() async throws {
         let subscription = try VideoSubscription(profile: .init(qualityProfile: "h264,width=1920,height=1080,fps=30,br=2000",
                                                                 expiry: [1],
                                                                 priorities: [1],


### PR DESCRIPTION
- Move video participant / renderer to be owned by the subscription it belongs to. 
- Migrate `VideoParticipant` and `VideoParticipants` to use `@Observable`.
- Fix some threading issues. 