### PR TITLE
Handle changing video publication status

### DIFF
--- a/Decimus/Publications/H264Publication.swift
+++ b/Decimus/Publications/H264Publication.swift
@@ -192,8 +192,9 @@ class H264Publication: Publication, FrameListener {
         }
 
         // If we're not in a state to be publishing, don't go any further.
-        guard self.publish.load(ordering: .acquiring) else {
-            self.logger.debug("Didn't encode due to publication status")
+        let status = self.getStatus()
+        guard status == .ok || status == .subscriptionUpdated else {
+            self.logger.debug("Didn't encode due to publication status: \(status)")
             return
         }
 

--- a/Decimus/Publications/H264Publication.swift
+++ b/Decimus/Publications/H264Publication.swift
@@ -17,7 +17,7 @@ enum H264PublicationError: LocalizedError {
 }
 
 class H264Publication: Publication, FrameListener {
-    private static let logger = DecimusLogger(H264Publication.self)
+    private let logger = DecimusLogger(H264Publication.self)
 
     private let measurement: MeasurementRegistration<VideoPublicationMeasurement>?
 
@@ -34,6 +34,78 @@ class H264Publication: Publication, FrameListener {
     private var currentObjectId: UInt64 = 0
     private let generateKeyFrame = ManagedAtomic(false)
     private let stagger: Bool
+    private var publishFailure = ManagedAtomic(false)
+    private let verbose: Bool
+
+    // Encoded frames arrive in this callback.
+    private let onEncodedData: VTEncoder.EncodedCallback = { presentationDate, data, flag, sequence, userData in
+        guard let userData = userData else {
+            assert(false)
+            return
+        }
+        let publication = Unmanaged<H264Publication>.fromOpaque(userData).takeUnretainedValue()
+
+        // Determine group and object IDs.
+        let thisGroupId: UInt64
+        let thisObjectId: UInt64
+        if let currentGroupId = publication.currentGroupId {
+            if flag {
+                // Start new group on key frame.
+                thisGroupId = currentGroupId + 1
+                thisObjectId = 0
+            } else {
+                // Increment object ID in current GOP.
+                thisGroupId = currentGroupId
+                thisObjectId = publication.currentObjectId + 1
+            }
+        } else {
+            // Start initial group ID using current time.
+            thisGroupId = UInt64(Date.now.timeIntervalSince1970)
+            thisObjectId = 0
+        }
+
+        // Use extensions for LOC.
+        let loc = LowOverheadContainer(timestamp: presentationDate, sequence: sequence)
+
+        // Publish.
+        let data = Data(bytesNoCopy: .init(mutating: data.baseAddress!),
+                        count: data.count,
+                        deallocator: .none)
+        var priority = publication.getPriority(flag ? 0 : 1)
+        var ttl = publication.getTTL(flag ? 0 : 1)
+        let status = publication.publish(groupId: thisGroupId,
+                                         objectId: thisObjectId,
+                                         data: data,
+                                         priority: &priority,
+                                         ttl: &ttl,
+                                         extensions: loc.extensions)
+        switch status {
+        case .ok:
+            if publication.verbose {
+                publication.logger.debug("Published: \(thisGroupId): \(thisObjectId)")
+            }
+            publication.publishFailure.store(false, ordering: .releasing)
+        default:
+            publication.logger.warning("Failed to publish object: \(status)")
+            publication.publishFailure.store(true, ordering: .releasing)
+            return
+        }
+
+        // Update IDs on success.
+        publication.currentGroupId = thisGroupId
+        publication.currentObjectId = thisObjectId
+
+        // Metrics.
+        guard let measurement = publication.measurement else { return }
+        let bytes = data.count
+        let sent: Date? = publication.granularMetrics ? Date.now : nil
+        Task(priority: .utility) {
+            measurement.measurement.sentFrame(bytes: UInt64(bytes),
+                                              timestamp: presentationDate.timeIntervalSince1970,
+                                              age: sent?.timeIntervalSince(presentationDate) ?? nil,
+                                              metricsTimestamp: sent)
+        }
+    }
 
     required init(profile: Profile,
                   config: VideoCodecConfig,
@@ -44,7 +116,8 @@ class H264Publication: Publication, FrameListener {
                   device: AVCaptureDevice,
                   endpointId: String,
                   relayId: String,
-                  stagger: Bool) throws {
+                  stagger: Bool,
+                  verbose: Bool) throws {
         let namespace = profile.namespace.joined()
         self.granularMetrics = granularMetrics
         self.codec = config
@@ -60,91 +133,8 @@ class H264Publication: Publication, FrameListener {
         self.encoder = encoder
         self.device = device
         self.stagger = stagger
-
-        let onEncodedData: VTEncoder.EncodedCallback = { presentationDate, data, flag, sequence, userData in
-            guard let userData = userData else {
-                Self.logger.error("UserData unexpectedly was nil")
-                return
-            }
-            let publication = Unmanaged<H264Publication>.fromOpaque(userData).takeUnretainedValue()
-
-            // Encode age.
-            let now = publication.measurement != nil && granularMetrics ? Date.now : nil
-            if granularMetrics,
-               let measurement = publication.measurement {
-                let age = now!.timeIntervalSince(presentationDate)
-                Task(priority: .utility) {
-                    await measurement.measurement.encoded(age: age, timestamp: now!)
-                }
-            }
-
-            let thisGroupId: UInt64
-            let thisObjectId: UInt64
-            if let currentGroupId = publication.currentGroupId {
-                if flag {
-                    thisGroupId = currentGroupId + 1
-                    thisObjectId = 0
-                } else {
-                    thisGroupId = currentGroupId
-                    thisObjectId = publication.currentObjectId + 1
-                }
-            } else {
-                thisGroupId = UInt64(Date.now.timeIntervalSince1970)
-                thisObjectId = 0
-            }
-
-            // Use extensions for LOC.
-            let loc = LowOverheadContainer(timestamp: presentationDate, sequence: sequence)
-
-            // Publish.
-            let data = Data(bytesNoCopy: .init(mutating: data.baseAddress!),
-                            count: data.count,
-                            deallocator: .none)
-            var priority = publication.getPriority(flag ? 0 : 1)
-            var ttl = publication.getTTL(flag ? 0 : 1)
-            guard publication.publish.load(ordering: .acquiring) else {
-                Self.logger.warning("Didn't publish due to status: \(String(describing: publication.currentStatus))")
-                return
-            }
-            let status = publication.publish(groupId: thisGroupId,
-                                             objectId: thisObjectId,
-                                             data: data,
-                                             priority: &priority,
-                                             ttl: &ttl,
-                                             extensions: loc.extensions)
-            switch status {
-            case .ok:
-                break
-            default:
-                Self.logger.warning("Failed to publish object: \(status)")
-                _ = self.generateKeyFrame.compareExchange(expected: false,
-                                                          desired: true,
-                                                          ordering: .acquiringAndReleasing)
-                return
-            }
-
-            // Update IDs.
-            publication.currentGroupId = thisGroupId
-            publication.currentObjectId = thisObjectId
-
-            // Metrics.
-            guard let measurement = publication.measurement else { return }
-            let bytes = data.count
-            let sent: Date? = granularMetrics ? Date.now : nil
-            Task(priority: .utility) {
-                let age: TimeInterval?
-                if let sent = sent {
-                    age = sent.timeIntervalSince(presentationDate)
-                } else {
-                    age = nil
-                }
-                await measurement.measurement.sentFrame(bytes: UInt64(bytes),
-                                                        timestamp: presentationDate.timeIntervalSince1970,
-                                                        age: age,
-                                                        metricsTimestamp: sent)
-            }
-        }
-        Self.logger.info("Registered H264 publication for namespace \(namespace)")
+        self.verbose = verbose
+        self.logger.info("Registered H264 publication for namespace \(namespace)")
 
         guard let defaultPriority = profile.priorities?.first,
               let defaultTTL = profile.expiry?.first else {
@@ -157,17 +147,18 @@ class H264Publication: Publication, FrameListener {
                        defaultTTL: UInt16(clamping: defaultTTL),
                        submitter: metricsSubmitter,
                        endpointId: endpointId,
-                       relayId: relayId)
+                       relayId: relayId,
+                       logger: self.logger)
         let userData = Unmanaged.passUnretained(self).toOpaque()
         self.encoder.setCallback(onEncodedData, userData: userData)
     }
 
-    private func publish(groupId: UInt64,
-                         objectId: UInt64,
-                         data: Data,
-                         priority: UnsafePointer<UInt8>?,
-                         ttl: UnsafePointer<UInt16>?,
-                         extensions: [NSNumber: Data]) -> QPublishObjectStatus {
+    internal func publish(groupId: UInt64,
+                          objectId: UInt64,
+                          data: Data,
+                          priority: UnsafePointer<UInt8>?,
+                          ttl: UnsafePointer<UInt16>?,
+                          extensions: [NSNumber: Data]) -> QPublishObjectStatus {
         let headers = QObjectHeaders(groupId: groupId,
                                      objectId: objectId,
                                      payloadLength: UInt64(data.count),
@@ -177,7 +168,7 @@ class H264Publication: Publication, FrameListener {
     }
 
     deinit {
-        Self.logger.debug("Deinit")
+        self.logger.debug("Deinit")
     }
 
     override func statusChanged(_ status: QPublishTrackHandlerStatus) {
@@ -196,8 +187,14 @@ class H264Publication: Publication, FrameListener {
             self.encoder.frameRate = maxRate
         } else {
             if self.encoder.frameRate != maxRate {
-                Self.logger.warning("Frame rate mismatch? Had: \(String(describing: self.encoder.frameRate)), got: \(String(describing: maxRate))")
+                self.logger.warning("Frame rate mismatch? Had: \(String(describing: self.encoder.frameRate)), got: \(String(describing: maxRate))")
             }
+        }
+
+        // If we're not in a state to be publishing, don't go any further.
+        guard self.publish.load(ordering: .acquiring) else {
+            self.logger.debug("Didn't encode due to publication status")
+            return
         }
 
         // Stagger the publication's start time by its height in ms.
@@ -207,22 +204,39 @@ class H264Publication: Publication, FrameListener {
                 return
             }
             let interval = timestamp.timeIntervalSince(startTime)
-            guard interval > TimeInterval(self.codec!.height) / 1000.0 else { return }
+            guard interval > TimeInterval(self.codec!.height) / 1000.0 else {
+                self.logger.debug("Dropping due to stagger")
+                return
+            }
         }
 
         // Should we be forcing a key frame?
-        let (keyFrame, _) = self.generateKeyFrame.compareExchange(expected: true,
-                                                                  desired: false,
-                                                                  ordering: .acquiringAndReleasing)
-        if keyFrame {
-            Self.logger.debug("Forcing key frame")
+        var keyFrame: Bool {
+            // If the last publish failed, we need a key frame.
+            guard !self.publishFailure.load(ordering: .acquiring) else {
+                self.logger.debug("Forcing key frame - last time didn't publish")
+                // Consume any existing request.
+                _ = self.generateKeyFrame.compareExchange(expected: true,
+                                                          desired: false,
+                                                          ordering: .acquiringAndReleasing)
+                return true
+            }
+
+            // If we asked for key frame, make one (subscribe update).
+            let (generate, _) = self.generateKeyFrame.compareExchange(expected: true,
+                                                                      desired: false,
+                                                                      ordering: .acquiringAndReleasing)
+            if generate {
+                self.logger.debug("Forcing key frame - subscribe update")
+            }
+            return generate
         }
 
         // Encode.
         do {
             try encoder.write(sample: sampleBuffer, timestamp: timestamp, forceKeyFrame: keyFrame)
         } catch {
-            Self.logger.error("Failed to encode frame: \(error.localizedDescription)")
+            self.logger.error("Failed to encode frame: \(error.localizedDescription)")
         }
 
         // Metrics.

--- a/Decimus/Publications/H264Publication.swift
+++ b/Decimus/Publications/H264Publication.swift
@@ -60,6 +60,7 @@ class H264Publication: Publication, FrameListener {
             }
         } else {
             // Start initial group ID using current time.
+            assert(flag)
             thisGroupId = UInt64(Date.now.timeIntervalSince1970)
             thisObjectId = 0
         }

--- a/Decimus/Publications/OpusPublication.swift
+++ b/Decimus/Publications/OpusPublication.swift
@@ -117,8 +117,9 @@ class OpusPublication: Publication {
             }
         }
 
-        guard self.publish.load(ordering: .acquiring) else {
-            Self.logger.warning("Not published due to status")
+        let status = self.getStatus()
+        guard status == .ok || status == .subscriptionUpdated else {
+            Self.logger.warning("Not published due to status: \(status)")
             return
         }
         var priority = self.getPriority(0)

--- a/Decimus/Publications/OpusPublication.swift
+++ b/Decimus/Publications/OpusPublication.swift
@@ -71,7 +71,8 @@ class OpusPublication: Publication {
                        defaultTTL: UInt16(clamping: defaultTTL),
                        submitter: metricsSubmitter,
                        endpointId: endpointId,
-                       relayId: relayId)
+                       relayId: relayId,
+                       logger: Self.logger)
 
         // Setup encode job.
         self.encodeTask = .init(priority: .userInitiated) { [weak self] in

--- a/Decimus/Publications/PublicationFactory.swift
+++ b/Decimus/Publications/PublicationFactory.swift
@@ -22,6 +22,7 @@ class PublicationFactoryImpl: PublicationFactory {
     private let keyFrameInterval: TimeInterval
     private let stagger: Bool
     private let logger = DecimusLogger(PublicationFactory.self)
+    private let verbose: Bool
 
     init(opusWindowSize: OpusWindowSize,
          reliability: MediaReliability,
@@ -31,7 +32,8 @@ class PublicationFactoryImpl: PublicationFactory {
          captureManager: CaptureManager,
          participantId: ParticipantId,
          keyFrameInterval: TimeInterval,
-         stagger: Bool) {
+         stagger: Bool,
+         verbose: Bool) {
         self.opusWindowSize = opusWindowSize
         self.reliability = reliability
         self.engine = engine
@@ -41,6 +43,7 @@ class PublicationFactoryImpl: PublicationFactory {
         self.participantId = participantId
         self.keyFrameInterval = keyFrameInterval
         self.stagger = stagger
+        self.verbose = verbose
     }
 
     func create(publication: ManifestPublication,
@@ -110,7 +113,8 @@ class PublicationFactoryImpl: PublicationFactory {
                                                   device: device,
                                                   endpointId: endpointId,
                                                   relayId: relayId,
-                                                  stagger: self.stagger)
+                                                  stagger: self.stagger,
+                                                  verbose: self.verbose)
             try self.captureManager.addInput(publication)
             return publication
         case .opus:

--- a/Decimus/Views/InCallView.swift
+++ b/Decimus/Views/InCallView.swift
@@ -302,6 +302,9 @@ extension InCallView {
         @AppStorage(PlaytimeSettingsView.defaultsKey)
         private(set) var playtimeConfig: AppStorageWrapper<PlaytimeSettings> = .init(value: .init())
 
+        @AppStorage(SettingsView.verboseKey)
+        private(set) var verbose = false
+
         init(config: CallConfig, onLeave: @escaping () -> Void) {
             self.config = config
             self.onLeave = onLeave
@@ -359,7 +362,8 @@ extension InCallView {
                                                             captureManager: captureManager,
                                                             participantId: manifest.participantId,
                                                             keyFrameInterval: subConfig.keyFrameInterval,
-                                                            stagger: subConfig.stagger)
+                                                            stagger: subConfig.stagger,
+                                                            verbose: self.verbose)
             let playtime = self.playtimeConfig.value
             let ourParticipantId = (playtime.playtime && playtime.echo) ? nil : manifest.participantId
             let subscriptionFactory = SubscriptionFactoryImpl(videoParticipants: self.videoParticipants,

--- a/Decimus/Views/Settings/SettingsView.swift
+++ b/Decimus/Views/Settings/SettingsView.swift
@@ -35,6 +35,7 @@ struct SettingsView: View {
                         self.logger.warning("Failed to reset settings: \(error.localizedDescription)", alert: true)
                     }
                     UserDefaults.standard.removeObject(forKey: SubscriptionSettingsView.defaultsKey)
+                    UserDefaults.standard.removeObject(forKey: SettingsView.verboseKey)
                 }
             }
             .buttonStyle(BorderedButtonStyle())

--- a/Decimus/Views/Settings/SettingsView.swift
+++ b/Decimus/Views/Settings/SettingsView.swift
@@ -8,6 +8,10 @@ struct SettingsView: View {
     @State private var cancelConfirmation = false
     private let logger = DecimusLogger(SettingsView.self)
 
+    static let verboseKey = "verbose"
+    @AppStorage(Self.verboseKey)
+    private var verbose: Bool = false
+
     var body: some View {
         // Reset all.
         HStack {
@@ -51,6 +55,11 @@ struct SettingsView: View {
 
             SubscriptionSettingsView()
                 .decimusTextStyle()
+
+            Section("Debug") {
+                Toggle("Verbose Logging", isOn: self.$verbose)
+            }
+            .decimusTextStyle()
 
             PlaytimeSettingsView()
                 .decimusTextStyle()

--- a/Tests/TestCallController.swift
+++ b/Tests/TestCallController.swift
@@ -39,7 +39,8 @@ final class TestCallController: XCTestCase {
                                                       defaultTTL: 0,
                                                       submitter: nil,
                                                       endpointId: "",
-                                                      relayId: "")
+                                                      relayId: "",
+                                                      logger: DecimusLogger(TestPublication.self))
                 self.callback(publication)
                 pubs.append((ftn, publication))
             }

--- a/Tests/TestPublication.swift
+++ b/Tests/TestPublication.swift
@@ -15,7 +15,8 @@ final class TestPublication: XCTestCase {
                                           defaultTTL: expectedTTL,
                                           submitter: nil,
                                           endpointId: "",
-                                          relayId: "")
+                                          relayId: "",
+                                          logger: DecimusLogger(TestPublication.self))
         XCTAssertEqual(expectedPriority, publication.getPriority(.random(in: 0..<Int.max)))
         XCTAssertEqual(expectedTTL, publication.getTTL(.random(in: 0..<Int.max)))
     }
@@ -30,7 +31,8 @@ final class TestPublication: XCTestCase {
                                           defaultTTL: expectedTTL,
                                           submitter: nil,
                                           endpointId: "",
-                                          relayId: "")
+                                          relayId: "",
+                                          logger: DecimusLogger(TestPublication.self))
         XCTAssertEqual(5, publication.getPriority(0))
         XCTAssertEqual(6, publication.getPriority(1))
         XCTAssertEqual(expectedPriority, publication.getPriority(3))

--- a/Tests/TestVideoPublication.swift
+++ b/Tests/TestVideoPublication.swift
@@ -200,12 +200,12 @@ let badStatuses: [QPublishTrackHandlerStatus?] = [ nil,
 @Suite struct VideoPublicationTests {
     @Test("Only encode on valid status", arguments: badStatuses)
     func testEncodeWithStatus(_ status: QPublishTrackHandlerStatus?) async throws {
+        guard let device = AVCaptureDevice.systemPreferredCamera else {
+            _ = XCTSkip("Can't test without a camera")
+            return
+        }
         try await confirmation(expectedCount: 2) { confirmation in
             let encoder = MockEncoder { _, _, _ in confirmation() }
-            guard let device = AVCaptureDevice.systemPreferredCamera else {
-                _ = XCTSkip("Can't test without a camera")
-                return
-            }
             let config = VideoCodecConfig(codec: .h264,
                                           bitrate: 1_000_000,
                                           fps: 30,
@@ -246,15 +246,15 @@ let badStatuses: [QPublishTrackHandlerStatus?] = [ nil,
 
     @Test("Keyframe on subscribe update")
     func testKeyFrameOnPublishFailure() async throws {
+        guard let device = AVCaptureDevice.systemPreferredCamera else {
+            _ = XCTSkip("Can't test without a camera")
+            return
+        }
         var status: QPublishTrackHandlerStatus?
         try await confirmation(expectedCount: 3) { confirmation in
             let encoder = MockEncoder { _, _, keyFrame in
                 #expect(keyFrame == (status == .subscriptionUpdated))
                 confirmation()
-            }
-            guard let device = AVCaptureDevice.systemPreferredCamera else {
-                _ = XCTSkip("Can't test without a camera")
-                return
             }
 
             // Publications should be delayed by their height in ms.

--- a/Tests/TestVideoPublication.swift
+++ b/Tests/TestVideoPublication.swift
@@ -5,10 +5,11 @@
 import XCTest
 import CoreMedia
 import AVFoundation
+import Testing
 
 private class MockEncoder: VideoEncoder {
     var frameRate: Float64?
-    typealias WriteCallback = () -> Void
+    typealias WriteCallback = (_ sample: CMSampleBuffer, _ timestamp: Date, _ forceKeyFrame: Bool) -> Void
     private let callback: WriteCallback
 
     init(_ writeCallback: @escaping WriteCallback) {
@@ -16,7 +17,7 @@ private class MockEncoder: VideoEncoder {
     }
 
     func write(sample: CMSampleBuffer, timestamp: Date, forceKeyFrame: Bool) throws {
-        self.callback()
+        self.callback(sample, timestamp, forceKeyFrame)
     }
 
     func setCallback(_ callback: @escaping EncodedCallback, userData: UnsafeRawPointer?) {
@@ -24,39 +25,100 @@ private class MockEncoder: VideoEncoder {
     }
 }
 
-final class TestVideoPublication: XCTestCase {
+class FakeH264Publication: H264Publication {
+    typealias PublishCallback = (_ groupId: UInt64,
+                                 _ objectId: UInt64) -> Void
+    private let publishNotify: PublishCallback
 
-    private func makePublication(_ encoder: MockEncoder, height: Int32) throws -> H264Publication {
-        guard let device = AVCaptureDevice.systemPreferredCamera else {
-            throw XCTSkip("Can't test without a camera")
-        }
-
-        // Publications should be delayed by their height in ms.
-        let config = VideoCodecConfig(codec: .h264,
-                                      bitrate: 1_000_000,
-                                      fps: 30,
-                                      width: 1920,
-                                      height: height,
-                                      bitrateType: .average)
-
-        return try .init(profile: .init(qualityProfile: "",
-                                        expiry: [1, 2],
-                                        priorities: [1, 2],
-                                        namespace: [""]),
-                         config: config,
-                         metricsSubmitter: nil,
-                         reliable: true,
-                         granularMetrics: false,
-                         encoder: encoder,
-                         device: device,
-                         endpointId: "",
-                         relayId: "",
-                         stagger: true)
+    required init(profile: Profile,
+                  config: VideoCodecConfig,
+                  metricsSubmitter: (any MetricsSubmitter)?,
+                  reliable: Bool,
+                  granularMetrics: Bool,
+                  encoder: any VideoEncoder,
+                  device: AVCaptureDevice,
+                  endpointId: String,
+                  relayId: String,
+                  stagger: Bool,
+                  verbose: Bool,
+                  notify: @escaping PublishCallback) throws {
+        self.publishNotify = notify
+        try super.init(profile: profile,
+                       config: config,
+                       metricsSubmitter: metricsSubmitter,
+                       reliable: reliable,
+                       granularMetrics: granularMetrics,
+                       encoder: encoder,
+                       device: device,
+                       endpointId: endpointId,
+                       relayId: relayId,
+                       stagger: stagger,
+                       verbose: verbose)
     }
 
+    required init(profile: Profile,
+                  config: VideoCodecConfig,
+                  metricsSubmitter: (any MetricsSubmitter)?,
+                  reliable: Bool,
+                  granularMetrics: Bool,
+                  encoder: any VideoEncoder,
+                  device: AVCaptureDevice,
+                  endpointId: String,
+                  relayId: String,
+                  stagger: Bool,
+                  verbose: Bool) throws {
+        fatalError("init(profile:config:metricsSubmitter:reliable:granularMetrics:encoder:device:endpointId:relayId:stagger:verbose:) has not been implemented")
+    }
+
+    override func publish(groupId: UInt64,
+                          objectId: UInt64,
+                          data: Data,
+                          priority: UnsafePointer<UInt8>?,
+                          ttl: UnsafePointer<UInt16>?,
+                          extensions: [NSNumber: Data]) -> QPublishObjectStatus {
+        self.publishNotify(groupId, objectId)
+        return super.publish(groupId: groupId,
+                             objectId: objectId,
+                             data: data,
+                             priority: priority,
+                             ttl: ttl,
+                             extensions: extensions)
+    }
+}
+
+private func makePublication(_ encoder: MockEncoder, height: Int32, stagger: Bool) throws -> H264Publication {
+    guard let device = AVCaptureDevice.systemPreferredCamera else {
+        throw XCTSkip("Can't test without a camera")
+    }
+
+    // Publications should be delayed by their height in ms.
+    let config = VideoCodecConfig(codec: .h264,
+                                  bitrate: 1_000_000,
+                                  fps: 30,
+                                  width: 1920,
+                                  height: height,
+                                  bitrateType: .average)
+
+    return try .init(profile: .init(qualityProfile: "",
+                                    expiry: [1, 2],
+                                    priorities: [1, 2],
+                                    namespace: [""]),
+                     config: config,
+                     metricsSubmitter: nil,
+                     reliable: true,
+                     granularMetrics: false,
+                     encoder: encoder,
+                     device: device,
+                     endpointId: "",
+                     relayId: "",
+                     stagger: stagger,
+                     verbose: true)
+}
+
+final class TestVideoPublication: XCTestCase {
     func testPublicationStartDelay() throws {
         var shouldFire = false
-        let mockEncoder = MockEncoder {
+        let mockEncoder = MockEncoder { _, _, _ in
             guard shouldFire else {
                 XCTFail()
                 return
@@ -64,7 +126,7 @@ final class TestVideoPublication: XCTestCase {
         }
 
         let height: Int32 = 1080
-        let publication = try self.makePublication(mockEncoder, height: height)
+        let publication = try makePublication(mockEncoder, height: height, stagger: true)
 
         // Mock sample.
         let sample = try CMSampleBuffer(dataBuffer: nil,
@@ -101,8 +163,103 @@ final class TestVideoPublication: XCTestCase {
                                                        tx_queue_size: minMax,
                                                        tx_callback_ms: minMax,
                                                        tx_object_duration_us: minMax))
-        let publication = try self.makePublication(.init({
-        }), height: 1080)
+        let publication = try makePublication(.init({_, _, _ in}), height: 1080, stagger: false)
         publication.metricsSampled(metrics)
+    }
+}
+
+let badStatuses: [QPublishTrackHandlerStatus?] = [ nil,
+                                                   .announceNotAuthorized,
+                                                   .noSubscribers,
+                                                   .notAnnounced,
+                                                   .notConnected,
+                                                   .pendingAnnounceResponse,
+                                                   .sendingUnannounce]
+
+@Suite struct VideoPublicationTests {
+    @Test("Only encode on valid status", arguments: badStatuses)
+    func testEncodeWithStatus(_ status: QPublishTrackHandlerStatus?) async throws {
+        try await confirmation(expectedCount: 2) { confirmation in
+            let publication = try makePublication(.init({ _, _, _ in confirmation() }),
+                                                  height: 1080,
+                                                  stagger: false)
+            let sample = try CMSampleBuffer(dataBuffer: nil,
+                                            formatDescription: nil,
+                                            numSamples: 1,
+                                            sampleTimings: [],
+                                            sampleSizes: [])
+            let startDate = Date.now
+            if let status = status {
+                publication.statusChanged(status)
+            }
+            publication.onFrame(sample, timestamp: startDate)
+            publication.statusChanged(.ok)
+            publication.onFrame(sample, timestamp: startDate)
+            publication.statusChanged(.subscriptionUpdated)
+            publication.onFrame(sample, timestamp: startDate)
+        }
+    }
+
+    @Test("Keyframe on subscribe update")
+    func testKeyFrameOnPublishFailure() async throws {
+        var status: QPublishTrackHandlerStatus?
+        try await confirmation(expectedCount: 3) { confirmation in
+            let encoder = MockEncoder { _, _, keyFrame in
+                #expect(keyFrame == (status == .subscriptionUpdated))
+                confirmation()
+            }
+            guard let device = AVCaptureDevice.systemPreferredCamera else {
+                throw XCTSkip("Can't test without a camera")
+            }
+
+            // Publications should be delayed by their height in ms.
+            let config = VideoCodecConfig(codec: .h264,
+                                          bitrate: 1_000_000,
+                                          fps: 30,
+                                          width: 1920,
+                                          height: 1920,
+                                          bitrateType: .average)
+            var lastObjectId: UInt64?
+            let publication = try FakeH264Publication(profile: .init(qualityProfile: "",
+                                                                     expiry: [1, 2],
+                                                                     priorities: [1, 2],
+                                                                     namespace: [""]),
+                                                      config: config,
+                                                      metricsSubmitter: nil,
+                                                      reliable: true,
+                                                      granularMetrics: false,
+                                                      encoder: encoder,
+                                                      device: device,
+                                                      endpointId: "",
+                                                      relayId: "",
+                                                      stagger: false,
+                                                      verbose: true) { _, objectId in
+                // When this is a key frame, object ID should be 0.
+                if status == .subscriptionUpdated {
+                    #expect(lastObjectId != 0)
+                    #expect(objectId == 0)
+                }
+                lastObjectId = objectId
+            }
+            let sample = try CMSampleBuffer(dataBuffer: nil,
+                                            formatDescription: nil,
+                                            numSamples: 1,
+                                            sampleTimings: [],
+                                            sampleSizes: [])
+            // pframe.
+            status = .ok
+            publication.statusChanged(status!)
+            publication.onFrame(sample, timestamp: .now)
+
+            // key frame.
+            status = .subscriptionUpdated
+            publication.statusChanged(status!)
+            publication.onFrame(sample, timestamp: .now)
+
+            // pframe.
+            status = .ok
+            publication.statusChanged(status!)
+            publication.onFrame(sample, timestamp: .now)
+        }
     }
 }


### PR DESCRIPTION
Better handle potential status changes on publications, primarily to stop the situation where an already existing but newly active subscription would start publishing in the middle of a GOP / group. 

Also adds verbose logging capability to get per-frame logs, useful for inspecting media / object flows. 