### PR TITLE
Make subscription cleanup configurable

### DIFF
--- a/Decimus/Subscriptions/OpusSubscription.swift
+++ b/Decimus/Subscriptions/OpusSubscription.swift
@@ -15,7 +15,7 @@ class OpusSubscription: Subscription {
     private let handlerLock = OSAllocatedUnfairLock()
     private var handler: OpusHandler?
     private var cleanupTask: Task<(), Never>?
-    private let cleanupTimer: TimeInterval = 1.5
+    private let cleanupTimer: TimeInterval
     private var lastUpdateTime: Date?
     private let jitterDepth: TimeInterval
     private let jitterMax: TimeInterval
@@ -35,6 +35,7 @@ class OpusSubscription: Subscription {
          endpointId: String,
          relayId: String,
          useNewJitterBuffer: Bool,
+         cleanupTime: TimeInterval,
          statusChanged: @escaping StatusCallback) throws {
         self.profile = profile
         self.engine = engine
@@ -51,6 +52,7 @@ class OpusSubscription: Subscription {
         self.reliable = reliable
         self.granularMetrics = granularMetrics
         self.useNewJitterBuffer = useNewJitterBuffer
+        self.cleanupTimer = cleanupTime
 
         // Create the actual audio handler upfront.
         self.handler = try .init(identifier: self.profile.namespace.joined(),

--- a/Decimus/Subscriptions/SubscriptionFactory.swift
+++ b/Decimus/Subscriptions/SubscriptionFactory.swift
@@ -96,6 +96,8 @@ struct SubscriptionConfig: Codable {
     var doSFrame: Bool
     /// True to publish keyframe on subscribe update.
     var keyFrameOnUpdate: Bool
+    /// Time to cleanup stale subscriptions for.
+    var cleanupTime: TimeInterval
 
     /// Create with default settings.
     init() {
@@ -125,6 +127,7 @@ struct SubscriptionConfig: Codable {
         doSFrame = true
         stagger = true
         self.keyFrameOnUpdate = true
+        self.cleanupTime = 1.5
     }
 }
 
@@ -218,7 +221,8 @@ class SubscriptionFactoryImpl: SubscriptionFactory {
                                             endpointId: endpointId,
                                             relayId: relayId,
                                             codecFactory: CodecFactoryImpl(),
-                                            joinDate: self.joinDate)
+                                            joinDate: self.joinDate,
+                                            cleanupTime: self.subscriptionConfig.cleanupTime)
         }
 
         if found.isSubset(of: opusCodecs) {
@@ -288,6 +292,7 @@ class SubscriptionFactoryImpl: SubscriptionFactory {
                                          relayId: relayId,
                                          participantId: set.participantId,
                                          joinDate: self.joinDate,
+                                         cleanupTime: self.subscriptionConfig.cleanupTime,
                                          callback: { [weak set] timestamp, when in
                                             guard let set = set else { return }
                                             set.receivedObject(ftn, timestamp: timestamp, when: when)
@@ -308,6 +313,7 @@ class SubscriptionFactoryImpl: SubscriptionFactory {
                                         endpointId: endpointId,
                                         relayId: relayId,
                                         useNewJitterBuffer: self.subscriptionConfig.useNewJitterBuffer,
+                                        cleanupTime: self.subscriptionConfig.cleanupTime,
                                         statusChanged: unregister)
         }
         throw CodecError.invalidCodecConfig(config)

--- a/Decimus/Subscriptions/VideoSubscription.swift
+++ b/Decimus/Subscriptions/VideoSubscription.swift
@@ -27,7 +27,7 @@ class VideoSubscription: Subscription {
     let handlerLock = OSAllocatedUnfairLock()
 
     private var cleanupTask: Task<(), Never>?
-    private let cleanupTimer: TimeInterval = 1.5
+    private let cleanupTimer: TimeInterval
     private var lastUpdateTime = Date.now
     private let participantId: ParticipantId
     private let creationDate: Date
@@ -47,6 +47,7 @@ class VideoSubscription: Subscription {
          relayId: String,
          participantId: ParticipantId,
          joinDate: Date,
+         cleanupTime: TimeInterval,
          callback: @escaping ObjectReceived,
          statusChanged: @escaping StatusChanged) throws {
         self.fullTrackName = try profile.getFullTrackName()
@@ -63,6 +64,7 @@ class VideoSubscription: Subscription {
         self.participantId = participantId
         self.creationDate = .now
         self.joinDate = joinDate
+        self.cleanupTimer = cleanupTime
         let handler = try VideoHandler(fullTrackName: fullTrackName,
                                        config: config,
                                        participants: participants,

--- a/Decimus/Subscriptions/VideoSubscriptionSet.swift
+++ b/Decimus/Subscriptions/VideoSubscriptionSet.swift
@@ -39,7 +39,7 @@ class VideoSubscriptionSet: ObservableSubscriptionSet {
     private var lastUpdateTime = Date.now
     private var handlerLock = OSAllocatedUnfairLock()
     private let profiles: [FullTrackName: VideoCodecConfig]
-    private let cleanupTimer: TimeInterval = 1.5
+    private let cleanupTimer: TimeInterval
     private var pauseMissCounts: [FullTrackName: Int] = [:]
     private let pauseMissThreshold: Int
     private let pauseResume: Bool
@@ -71,7 +71,8 @@ class VideoSubscriptionSet: ObservableSubscriptionSet {
          endpointId: String,
          relayId: String,
          codecFactory: CodecFactory,
-         joinDate: Date) throws {
+         joinDate: Date,
+         cleanupTime: TimeInterval) throws {
         if simulreceive != .none && jitterBufferConfig.mode == .layer {
             throw "Simulreceive and layer are not compatible"
         }
@@ -106,6 +107,7 @@ class VideoSubscriptionSet: ObservableSubscriptionSet {
         let subscribeDate = Date.now
         self.subscribeDate = subscribeDate
         self.joinDate = joinDate
+        self.cleanupTimer = cleanupTime
 
         // Adjust and store expected quality profiles.
         var createdProfiles: [FullTrackName: VideoCodecConfig] = [:]

--- a/Decimus/Views/Settings/SubscriptionSettingsView.swift
+++ b/Decimus/Views/Settings/SubscriptionSettingsView.swift
@@ -158,6 +158,14 @@ struct SubscriptionSettingsView: View {
                                formatStyle: IntegerFormatStyle<Int>.number.grouping(.never),
                                name: "Threshold")
                 }
+
+                LabeledContent("Cleanup Time (s)") {
+                    TextField(
+                        "Cleanup Time (s)",
+                        value: self.$subscriptionConfig.value.cleanupTime,
+                        format: .number)
+                        .labelsHidden()
+                }
             }
             .formStyle(.columns)
         }

--- a/Tests/TestVideoSubscription.swift
+++ b/Tests/TestVideoSubscription.swift
@@ -24,6 +24,7 @@ final class TestVideoSubscription: XCTestCase {
                                                  relayId: "",
                                                  participantId: .init(1),
                                                  joinDate: .now,
+                                                 cleanupTime: 1.5,
                                                  callback: ({ _, _ in }),
                                                  statusChanged: ({_ in }))
         subscription.metricsSampled(.init())


### PR DESCRIPTION
The Subscription cleanup timer (on no data objects) is now configurable. 