### PR TITLE
Update plist for iOS mDNS permissions

### DIFF
--- a/Decimus/Info.plist
+++ b/Decimus/Info.plist
@@ -2,6 +2,10 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>NSBonjourServices</key>
+	<array>
+		<string>_laps._udp</string>
+	</array>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>NSAppTransportSecurity</key>

--- a/Decimus/Views/Settings/RelaySettingsView.swift
+++ b/Decimus/Views/Settings/RelaySettingsView.swift
@@ -22,18 +22,9 @@ struct RelaySettingsView: View {
                         ProgressView()
                     }
                 }
-                if self.relayConfig.value.usemDNS {
-                    LabeledContent("mDNS Type") {
-                        VStack {
-                            TextField("mDNS Type",
-                                      text: self.$relayConfig.value.mDNSType,
-                                      prompt: Text("_laps._udp"))
-                                .labelsHidden()
-                            if let dnsMessage = self.dnsMessage {
-                                Text(dnsMessage).foregroundStyle(.red).font(.footnote)
-                            }
-                        }
-                    }
+                if self.relayConfig.value.usemDNS,
+                   let dnsMessage = self.dnsMessage {
+                    Text(dnsMessage).foregroundStyle(.red).font(.footnote)
                 }
             }
 

--- a/QuicR.xcodeproj/project.pbxproj
+++ b/QuicR.xcodeproj/project.pbxproj
@@ -1351,6 +1351,7 @@
 				INFOPLIST_KEY_CFBundleDisplayName = QuicR;
 				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.business";
 				INFOPLIST_KEY_NSCameraUsageDescription = "QuicR needs your camera in order for others to see you in calls";
+				INFOPLIST_KEY_NSLocalNetworkUsageDescription = "$(PROJECT_NAME) can scan the network for a local relay";
 				INFOPLIST_KEY_NSMicrophoneUsageDescription = "QuicR needs your camera in order for others to see you in calls";
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
@@ -1427,6 +1428,7 @@
 				INFOPLIST_KEY_CFBundleDisplayName = QuicR;
 				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.business";
 				INFOPLIST_KEY_NSCameraUsageDescription = "QuicR needs your camera in order for others to see you in calls";
+				INFOPLIST_KEY_NSLocalNetworkUsageDescription = "$(PROJECT_NAME) can scan the network for a local relay";
 				INFOPLIST_KEY_NSMicrophoneUsageDescription = "QuicR needs your camera in order for others to see you in calls";
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;


### PR DESCRIPTION
mDNS on iOS needs the service type pre-declared. 