### PR TITLE
iOS18 Primitives

### DIFF
--- a/Config.xcconfig
+++ b/Config.xcconfig
@@ -4,4 +4,4 @@
 // Configuration settings file format documentation can be found at:
 // https://help.apple.com/xcode/#/dev745c5c974
 
-APP_VERSION=4.1.4
+APP_VERSION=4.2.4

--- a/Decimus/JitterBuffer.swift
+++ b/Decimus/JitterBuffer.swift
@@ -2,8 +2,8 @@
 // SPDX-License-Identifier: BSD-2-Clause
 
 import Foundation
-import Atomics
 import CoreMedia
+import Synchronization
 
 // swiftlint:disable force_cast
 
@@ -47,9 +47,9 @@ class JitterBuffer {
     private var buffer: CMBufferQueue
     private let measurement: MeasurementRegistration<JitterBufferMeasurement>?
     private let playingFromStart: Bool
-    private var play: ManagedAtomic<Bool>
-    private var lastSequenceRead = ManagedAtomic<UInt64>(0)
-    private var lastSequenceSet = ManagedAtomic<Bool>(false)
+    private let play: Atomic<Bool>
+    private let lastSequenceRead = Atomic<UInt64>(0)
+    private let lastSequenceSet = Atomic<Bool>(false)
 
     protocol JitterItem: AnyObject {
         var sequenceNumber: UInt64 { get }

--- a/Decimus/Mutex+Convenience.swift
+++ b/Decimus/Mutex+Convenience.swift
@@ -1,0 +1,18 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025 Cisco Systems
+// SPDX-License-Identifier: BSD-2-Clause
+
+import Synchronization
+
+extension Mutex {
+    /// Return the value managed by the Mutex.
+    public func get() -> Value {
+        self.withLock { $0 }
+    }
+}
+
+extension Mutex where Value: ExpressibleByNilLiteral {
+    /// Set the value of the mutex to nil.
+    public func clear() {
+        self.withLock { $0 = nil }
+    }
+}

--- a/Decimus/Publications/H264Publication.swift
+++ b/Decimus/Publications/H264Publication.swift
@@ -1,9 +1,9 @@
 // SPDX-FileCopyrightText: Copyright (c) 2023 Cisco Systems
 // SPDX-License-Identifier: BSD-2-Clause
 
-import Atomics
 import Foundation
 import AVFoundation
+import Synchronization
 
 enum H264PublicationError: LocalizedError {
     case noCamera(SourceIDType)
@@ -32,9 +32,9 @@ class H264Publication: Publication, FrameListener {
     private var startTime: Date?
     private var currentGroupId: UInt64?
     private var currentObjectId: UInt64 = 0
-    private let generateKeyFrame = ManagedAtomic(false)
+    private let generateKeyFrame = Atomic(false)
     private let stagger: Bool
-    private var publishFailure = ManagedAtomic(false)
+    private let publishFailure = Atomic(false)
     private let verbose: Bool
     private let keyFrameOnUpdate: Bool
 

--- a/Decimus/Publications/Publication.swift
+++ b/Decimus/Publications/Publication.swift
@@ -1,10 +1,6 @@
 // SPDX-FileCopyrightText: Copyright (c) 2023 Cisco Systems
 // SPDX-License-Identifier: BSD-2-Clause
 
-import Atomics
-
-private let unset: Int16 = -1
-
 class Publication: QPublishTrackHandlerObjC, QPublishTrackHandlerCallbacks {
     internal let profile: Profile
     private let logger: DecimusLogger

--- a/Decimus/SlidingWindow.swift
+++ b/Decimus/SlidingWindow.swift
@@ -2,21 +2,20 @@
 // SPDX-License-Identifier: BSD-2-Clause
 
 import DequeModule
-import os
+import Synchronization
 
 /// Container for a sliding time window of values
 /// whose validity is determined by age.
 class SlidingTimeWindow<T: Numeric> {
-    private var values: Deque<(timestamp: Date, value: T)>
+    private let values: Mutex<Deque<(timestamp: Date, value: T)>>
     private let length: TimeInterval
-    private let lock = OSAllocatedUnfairLock()
 
     /// Create a new sliding time window.
     /// - Parameter length: The length of the window.
     /// - Parameter reserved: Optionally, capacity to reserve in elements.
     init(length: TimeInterval, reserved: Int? = nil) {
         self.length = length
-        self.values = .init(minimumCapacity: reserved ?? 0)
+        self.values = .init(.init(minimumCapacity: reserved ?? 0))
     }
 
     /// Add a timestamped value to the window.
@@ -24,24 +23,22 @@ class SlidingTimeWindow<T: Numeric> {
     ///  - timestamp: The timestamp of the value.
     ///  - value: The value to add.
     func add(timestamp: Date, value: T) {
-        self.lock.withLock {
-            self.values.append((timestamp, value))
-        }
+        self.values.withLock { $0.append((timestamp, value)) }
     }
 
     /// Given a point in time, return all older values within the window.
     /// - Parameter from: The time from which the window will start.
     /// - Returns: An array of values no older than the window.
     func get(from: Date) -> [T] {
-        self.lock.withLock {
+        self.values.withLock { values in
             var toRemove = IndexSet()
-            for index in self.values.indices {
-                let element = self.values[index]
+            for index in values.indices {
+                let element = values[index]
                 guard from.timeIntervalSince(element.timestamp) > self.length else { break }
                 toRemove.insert(index)
             }
-            self.values.remove(atOffsets: toRemove)
-            return self.values.reduce(into: []) { $0.append($1.value) }
+            values.remove(atOffsets: toRemove)
+            return values.reduce(into: []) { $0.append($1.value) }
         }
     }
 }

--- a/Decimus/Subscriptions/OpusSubscription.swift
+++ b/Decimus/Subscriptions/OpusSubscription.swift
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2023 Cisco Systems
 // SPDX-License-Identifier: BSD-2-Clause
 
-import os
+import Synchronization
 
 class OpusSubscription: Subscription {
     private static let logger = DecimusLogger(OpusSubscription.self)
@@ -12,11 +12,10 @@ class OpusSubscription: Subscription {
     private let reliable: Bool
     private let granularMetrics: Bool
     private var seq: UInt64 = 0
-    private let handlerLock = OSAllocatedUnfairLock()
-    private var handler: OpusHandler?
+    private let handler: Mutex<OpusHandler?>
     private var cleanupTask: Task<(), Never>?
     private let cleanupTimer: TimeInterval
-    private var lastUpdateTime: Date?
+    private let lastUpdateTime = Mutex<Date?>(nil)
     private let jitterDepth: TimeInterval
     private let jitterMax: TimeInterval
     private let opusWindowSize: OpusWindowSize
@@ -55,15 +54,15 @@ class OpusSubscription: Subscription {
         self.cleanupTimer = cleanupTime
 
         // Create the actual audio handler upfront.
-        self.handler = try .init(identifier: self.profile.namespace.joined(),
-                                 engine: self.engine,
-                                 measurement: self.measurement,
-                                 jitterDepth: self.jitterDepth,
-                                 jitterMax: self.jitterMax,
-                                 opusWindowSize: self.opusWindowSize,
-                                 granularMetrics: self.granularMetrics,
-                                 useNewJitterBuffer: self.useNewJitterBuffer,
-                                 metricsSubmitter: self.metricsSubmitter)
+        self.handler = try .init(.init(identifier: self.profile.namespace.joined(),
+                                       engine: self.engine,
+                                       measurement: self.measurement,
+                                       jitterDepth: self.jitterDepth,
+                                       jitterMax: self.jitterMax,
+                                       opusWindowSize: self.opusWindowSize,
+                                       granularMetrics: self.granularMetrics,
+                                       useNewJitterBuffer: self.useNewJitterBuffer,
+                                       metricsSubmitter: self.metricsSubmitter))
         let fullTrackName = try profile.getFullTrackName()
         self.fullTrackName = fullTrackName
         try super.init(profile: profile,
@@ -81,12 +80,11 @@ class OpusSubscription: Subscription {
                 let sleepTimer: TimeInterval
                 if let self = self {
                     sleepTimer = self.cleanupTimer
-                    self.handlerLock.withLock {
-                        // Remove the audio handler if expired.
-                        guard let lastUpdateTime = self.lastUpdateTime else { return }
+                    self.lastUpdateTime.withLock { lockedUpdateTime in
+                        guard let lastUpdateTime = lockedUpdateTime else { return }
                         if Date.now.timeIntervalSince(lastUpdateTime) >= self.cleanupTimer {
-                            self.lastUpdateTime = nil
-                            self.handler = nil
+                            lockedUpdateTime = nil
+                            self.handler.clear()
                         }
                     }
                 } else {
@@ -107,7 +105,7 @@ class OpusSubscription: Subscription {
 
     override func objectReceived(_ objectHeaders: QObjectHeaders, data: Data, extensions: [NSNumber: Data]?) {
         let now: Date = .now
-        self.lastUpdateTime = now
+        self.lastUpdateTime.withLock { $0 = now }
 
         // Metrics.
         let date: Date? = self.granularMetrics ? now : nil
@@ -131,8 +129,8 @@ class OpusSubscription: Subscription {
         // Do we need to create the handler?
         let handler: OpusHandler
         do {
-            handler = try self.handlerLock.withLock {
-                guard let handler = self.handler else {
+            handler = try self.handler.withLock { lockedHandler in
+                guard let handler = lockedHandler else {
                     let handler = try OpusHandler(identifier: self.profile.namespace.joined(),
                                                   engine: self.engine,
                                                   measurement: self.measurement,
@@ -142,7 +140,7 @@ class OpusSubscription: Subscription {
                                                   granularMetrics: self.granularMetrics,
                                                   useNewJitterBuffer: self.useNewJitterBuffer,
                                                   metricsSubmitter: self.metricsSubmitter)
-                    self.handler = handler
+                    lockedHandler = handler
                     return handler
                 }
                 return handler

--- a/Decimus/Subscriptions/VideoHandler.swift
+++ b/Decimus/Subscriptions/VideoHandler.swift
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: BSD-2-Clause
 
 import AVFoundation
-import Atomics
 import os
 import Synchronization
 
@@ -51,8 +50,8 @@ class VideoHandler: CustomStringConvertible { // swiftlint:disable:this type_bod
     var verticalMirror: Bool {
         atomicMirror.load(ordering: .acquiring)
     }
-    private var atomicOrientation = ManagedAtomic<UInt8>(0)
-    private var atomicMirror = ManagedAtomic<Bool>(false)
+    private let atomicOrientation = Atomic<UInt8>(0)
+    private let atomicMirror = Atomic<Bool>(false)
     private var currentFormat: CMFormatDescription?
     private var startTimeSet = false
     private let metricsSubmitter: MetricsSubmitter?

--- a/Decimus/Subscriptions/VideoSubscription.swift
+++ b/Decimus/Subscriptions/VideoSubscription.swift
@@ -1,8 +1,8 @@
 // SPDX-FileCopyrightText: Copyright (c) 2023 Cisco Systems
 // SPDX-License-Identifier: BSD-2-Clause
 
-import Atomics
 import os
+import Synchronization
 
 /// Represents a QuicR video subscription.
 /// Holds an object for decoding & rendering.
@@ -41,7 +41,7 @@ class VideoSubscription: Subscription {
     private let controller: MoqCallController
     private var fetch: Fetch?
     private var fetched = false
-    private var postCleanup = ManagedAtomic(false)
+    private let postCleanup = Atomic(false)
 
     init(profile: Profile,
          config: VideoCodecConfig,

--- a/Decimus/Subscriptions/VideoSubscription.swift
+++ b/Decimus/Subscriptions/VideoSubscription.swift
@@ -1,7 +1,6 @@
 // SPDX-FileCopyrightText: Copyright (c) 2023 Cisco Systems
 // SPDX-License-Identifier: BSD-2-Clause
 
-import os
 import Synchronization
 
 /// Represents a QuicR video subscription.
@@ -25,8 +24,7 @@ class VideoSubscription: Subscription {
     private let logger = DecimusLogger(VideoSubscription.self)
     private let verbose: Bool
 
-    var handler: VideoHandler?
-    let handlerLock = OSAllocatedUnfairLock()
+    let handler: Mutex<VideoHandler?>
 
     private var cleanupTask: Task<(), Never>?
     private let cleanupTimer: TimeInterval
@@ -95,7 +93,7 @@ class VideoSubscription: Subscription {
                                        subscribeDate: self.creationDate,
                                        joinDate: joinDate)
         self.token = handler.registerCallback(callback)
-        self.handler = handler
+        self.handler = .init(handler)
         try super.init(profile: profile,
                        endpointId: endpointId,
                        relayId: relayId,
@@ -111,9 +109,9 @@ class VideoSubscription: Subscription {
     }
 
     private func cleanup() {
-        self.handlerLock.withLock {
-            guard let handler = self.handler else { return }
-            self.handler = nil
+        self.handler.withLock { lockedHandler in
+            guard let handler = lockedHandler else { return }
+            lockedHandler = nil
             handler.unregisterCallback(self.token)
             self.token = 0
         }
@@ -198,30 +196,30 @@ class VideoSubscription: Subscription {
     }
 
     private func getCreateHandler() throws -> VideoHandler {
-        self.handlerLock.lock()
-        let handler: VideoHandler
-        if let unwrapped = self.handler {
-            handler = unwrapped
-        } else {
-            let recreated = try VideoHandler(fullTrackName: self.fullTrackName,
-                                             config: self.config,
-                                             participants: self.participants,
-                                             metricsSubmitter: self.metricsSubmitter,
-                                             videoBehaviour: self.videoBehaviour,
-                                             reliable: self.reliable,
-                                             granularMetrics: self.granularMetrics,
-                                             jitterBufferConfig: self.jitterBufferConfig,
-                                             simulreceive: self.simulreceive,
-                                             variances: self.variances,
-                                             participantId: self.participantId,
-                                             subscribeDate: self.creationDate,
-                                             joinDate: self.joinDate)
-            self.token = recreated.registerCallback(self.callback)
-            self.handler = recreated
-            handler = recreated
+        try self.handler.withLock { lockedHandler in
+            let handler: VideoHandler
+            if let unwrapped = lockedHandler {
+                handler = unwrapped
+            } else {
+                let recreated = try VideoHandler(fullTrackName: self.fullTrackName,
+                                                 config: self.config,
+                                                 participants: self.participants,
+                                                 metricsSubmitter: self.metricsSubmitter,
+                                                 videoBehaviour: self.videoBehaviour,
+                                                 reliable: self.reliable,
+                                                 granularMetrics: self.granularMetrics,
+                                                 jitterBufferConfig: self.jitterBufferConfig,
+                                                 simulreceive: self.simulreceive,
+                                                 variances: self.variances,
+                                                 participantId: self.participantId,
+                                                 subscribeDate: self.creationDate,
+                                                 joinDate: self.joinDate)
+                self.token = recreated.registerCallback(self.callback)
+                lockedHandler = recreated
+                handler = recreated
+            }
+            return handler
         }
-        self.handlerLock.unlock()
-        return handler
     }
 
     private func fetch(currentGroup: UInt64, currentObject: UInt64) throws {
@@ -268,7 +266,7 @@ class VideoSubscription: Subscription {
         if self.verbose {
             self.logger.debug("Fetched: \(headers.groupId):\(headers.objectId)")
         }
-        guard let handler = self.handler else { return }
+        guard let handler = self.handler.get() else { return }
         handler.objectReceived(headers, data: data, extensions: extensions, when: .now, cached: true)
 
         // Are we done?

--- a/Decimus/Subscriptions/VideoSubscriptionSet.swift
+++ b/Decimus/Subscriptions/VideoSubscriptionSet.swift
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: BSD-2-Clause
 
 import Synchronization
-import Atomics
 import os
 import CoreMedia
 

--- a/Decimus/Subscriptions/VideoSubscriptionSet.swift
+++ b/Decimus/Subscriptions/VideoSubscriptionSet.swift
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: BSD-2-Clause
 
 import Synchronization
-import os
 import CoreMedia
 
 enum SimulreceiveMode: Codable, CaseIterable, Identifiable {
@@ -38,7 +37,6 @@ class VideoSubscriptionSet: ObservableSubscriptionSet {
     private let qualityMissThreshold: Int
     private var cleanupTask: Task<(), Never>?
     private var lastUpdateTime = Date.now
-    private var handlerLock = OSAllocatedUnfairLock()
     private let profiles: [FullTrackName: VideoCodecConfig]
     private let cleanupTimer: TimeInterval
     private var pauseMissCounts: [FullTrackName: Int] = [:]
@@ -51,11 +49,8 @@ class VideoSubscriptionSet: ObservableSubscriptionSet {
     private let variances: VarianceCalculator
     let decodedVariances: VarianceCalculator
     private let timestampTimeDiff = Atomic<Int128>(0)
-    private var liveSubscriptions: Set<FullTrackName> = []
-    private let liveSubscriptionsLock = OSAllocatedUnfairLock()
     private let subscribeDate: Date
-    private var participant: VideoParticipant?
-    private let participantLock = OSAllocatedUnfairLock()
+    private let participant = Mutex<VideoParticipant?>(nil)
     private let joinDate: Date
     private let diffWindow: SlidingTimeWindow<TimeInterval>
     private var windowMaintenance: Task<(), Never>?
@@ -142,7 +137,7 @@ class VideoSubscriptionSet: ObservableSubscriptionSet {
                     if let self = self {
                         time = self.cleanupTimer
                         if Date.now.timeIntervalSince(self.lastUpdateTime) >= self.cleanupTimer {
-                            self.participantLock.withLock { self.participant = nil }
+                            self.participant.clear()
                         }
                     } else {
                         return
@@ -175,7 +170,7 @@ class VideoSubscriptionSet: ObservableSubscriptionSet {
            self.getHandlers().isEmpty {
             Self.logger.debug("Destroying simulreceive render as no live subscriptions")
             self.renderTask?.cancel()
-            self.participantLock.withLock { self.participant = nil }
+            self.participant.clear()
         }
         return result
     }
@@ -190,7 +185,7 @@ class VideoSubscriptionSet: ObservableSubscriptionSet {
         let subscriptions = self.getHandlers()
         for (_, sub) in subscriptions {
             let sub = sub as! VideoSubscription // swiftlint:disable:this force_cast
-            guard let handler = sub.handlerLock.withLock({ sub.handler }) else { continue }
+            guard let handler = sub.handler.get() else { continue }
             handler.setTimeDiff(diff: calculated)
         }
     }
@@ -317,7 +312,6 @@ class VideoSubscriptionSet: ObservableSubscriptionSet {
         }
     }
 
-    // Caller must lock handlerLock.
     // swiftlint:disable cyclomatic_complexity
     // swiftlint:disable function_body_length
     private func makeSimulreceiveDecision(at: Date) throws -> TimeInterval {
@@ -325,17 +319,15 @@ class VideoSubscriptionSet: ObservableSubscriptionSet {
         var initialChoices: [SimulreceiveItem] = []
         let subscriptions = self.getHandlers().mapValues { $0 as! VideoSubscription } // swiftlint:disable:this force_cast
         for subscription in subscriptions {
-            guard let handler = subscription.value.handler else {
+            guard let handler = subscription.value.handler.get() else {
                 continue
             }
-            handler.lastDecodedImageLock.lock()
-            defer { handler.lastDecodedImageLock.unlock() }
-            if let available = handler.lastDecodedImage {
+            handler.lastDecodedImage.withLock { lockedImage in
+                guard let available = lockedImage else { return }
                 if let lastTime = self.lastImage?.image.presentationTimeStamp,
                    available.image.presentationTimeStamp <= lastTime {
                     // This would be backwards in time, so we'll never use it.
-                    handler.lastDecodedImage = nil
-                    continue
+                    lockedImage = nil
                 }
                 initialChoices.append(.init(fullTrackName: handler.fullTrackName, image: available))
             }
@@ -350,12 +342,12 @@ class VideoSubscriptionSet: ObservableSubscriptionSet {
             // Wait for next.
             let duration: TimeInterval
             if let lastNamespace = self.last,
-               let handler = subscriptions[lastNamespace]?.handler {
+               let handler = subscriptions[lastNamespace]?.handler.get() {
                 duration = handler.calculateWaitTime(from: at) ?? (1 / Double(handler.config.fps))
             } else {
                 var highestFps: UInt16 = 1
                 for subscription in subscriptions {
-                    guard let handler = subscription.value.handler else {
+                    guard let handler = subscription.value.handler.get() else {
                         continue
                     }
                     highestFps = max(highestFps, handler.config.fps)
@@ -367,12 +359,12 @@ class VideoSubscriptionSet: ObservableSubscriptionSet {
 
         // Consume all images from our shortlist.
         for choice in choices {
-            let handler = subscriptions[choice.fullTrackName]!.handler!
-            handler.lastDecodedImageLock.withLock {
-                let theirTime = handler.lastDecodedImage?.image.presentationTimeStamp
+            let handler = subscriptions[choice.fullTrackName]!.handler.get()!
+            handler.lastDecodedImage.withLock { lockedImage in
+                let theirTime = lockedImage?.image.presentationTimeStamp
                 let ourTime = choice.image.image.presentationTimeStamp
                 if theirTime == ourTime {
-                    handler.lastDecodedImage = nil
+                    lockedImage = nil
                 }
             }
         }
@@ -428,7 +420,7 @@ class VideoSubscriptionSet: ObservableSubscriptionSet {
         guard let subscription = subscriptions[selected.fullTrackName] else {
             throw "Missing expected subscription for namespace: \(selected.fullTrackName)"
         }
-        guard let handler = subscription.handler else {
+        guard let handler = subscription.handler.get() else {
             throw "Missing video hanler for namespace: \(selected.fullTrackName)"
         }
 
@@ -480,7 +472,7 @@ class VideoSubscriptionSet: ObservableSubscriptionSet {
             }
             var highestFps: UInt16 = 1
             for subscription in subscriptions {
-                guard let handler = subscription.value.handler else {
+                guard let handler = subscription.value.handler.get() else {
                     continue
                 }
                 highestFps = max(highestFps, handler.config.fps)
@@ -514,23 +506,26 @@ class VideoSubscriptionSet: ObservableSubscriptionSet {
             // If we don't yet have a participant, make one.
             Task {
                 await MainActor.run {
-                    self.participantLock.lock()
-                    let participant: VideoParticipant
-                    if let existing = self.participant {
-                        participant = existing
-                    } else {
-                        do {
-                            participant = try .init(id: self.sourceId,
-                                                    startDate: self.joinDate,
-                                                    subscribeDate: self.subscribeDate,
-                                                    videoParticipants: self.participants)
-                        } catch {
-                            self.participantLock.unlock()
-                            return
+                    let participant: VideoParticipant? = self.participant.withLock { lockedParticipant in
+                        let participant: VideoParticipant
+                        if let existing = lockedParticipant {
+                            participant = existing
+                        } else {
+                            do {
+                                participant = try .init(id: self.sourceId,
+                                                        startDate: self.joinDate,
+                                                        subscribeDate: self.subscribeDate,
+                                                        videoParticipants: self.participants)
+                                lockedParticipant = participant
+                            } catch {
+                                Self.logger.error("Failed to create participant: \(error.localizedDescription)")
+                                return nil
+                            }
                         }
-                        self.participant = participant
+                        return participant
                     }
-                    self.participantLock.unlock()
+
+                    guard let participant else { return }
                     if let dispatchLabel = dispatchLabel {
                         participant.label = dispatchLabel
                     }
@@ -568,7 +563,7 @@ class VideoSubscriptionSet: ObservableSubscriptionSet {
         }
         var highestFps: UInt16 = 1
         for subscription in subscriptions {
-            guard let handler = subscription.value.handler else {
+            guard let handler = subscription.value.handler.get() else {
                 continue
             }
             highestFps = max(highestFps, handler.config.fps)

--- a/Decimus/Subscriptions/VideoSubscriptionSet.swift
+++ b/Decimus/Subscriptions/VideoSubscriptionSet.swift
@@ -328,6 +328,7 @@ class VideoSubscriptionSet: ObservableSubscriptionSet {
                    available.image.presentationTimeStamp <= lastTime {
                     // This would be backwards in time, so we'll never use it.
                     lockedImage = nil
+                    return
                 }
                 initialChoices.append(.init(fullTrackName: handler.fullTrackName, image: available))
             }

--- a/QuicR.xcodeproj/project.pbxproj
+++ b/QuicR.xcodeproj/project.pbxproj
@@ -83,7 +83,6 @@
 		9B807A682CF5FFD1007C7E6E /* CallbackSubscription.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B807A672CF5FFCD007C7E6E /* CallbackSubscription.swift */; };
 		9B807A6A2CF60160007C7E6E /* ActiveSpeakerNotifierSubscription.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B807A692CF6015B007C7E6E /* ActiveSpeakerNotifierSubscription.swift */; };
 		9B87FB622A03B91E00C92DD1 /* SettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B87FB612A03B91E00C92DD1 /* SettingsView.swift */; };
-		9B8B6F682B9B01F700FBB0D1 /* Atomics in Frameworks */ = {isa = PBXBuildFile; productRef = 9B8B6F672B9B01F700FBB0D1 /* Atomics */; };
 		9B8B9D512BF37CC400F7AE34 /* VideoUtilities.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B8B9D502BF37CC400F7AE34 /* VideoUtilities.swift */; };
 		9B8B9D532BF3A42C00F7AE34 /* TestDecimusVideoFrame.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B8B9D522BF3A42C00F7AE34 /* TestDecimusVideoFrame.swift */; };
 		9B8E14DB2C7E935E009D8C24 /* QPublishTrackHandlerObjC.mm in Sources */ = {isa = PBXBuildFile; fileRef = 9B8E14D62C7E935E009D8C24 /* QPublishTrackHandlerObjC.mm */; };
@@ -417,7 +416,6 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				9B8B6F682B9B01F700FBB0D1 /* Atomics in Frameworks */,
 				18C89A3A2A13D1E4005B333B /* InfluxDBSwift in Frameworks */,
 				9BDD5B13299697DE00C01D54 /* DequeModule in Frameworks */,
 				18BF45782B0E0F3D006E8E24 /* TPCircularBuffer in Frameworks */,
@@ -846,7 +844,6 @@
 				188ABB552A792E9C00B31A6E /* Opus */,
 				18F7C4D92AB1C7BD005EDB88 /* OrderedCollections */,
 				18BF45772B0E0F3D006E8E24 /* TPCircularBuffer */,
-				9B8B6F672B9B01F700FBB0D1 /* Atomics */,
 			);
 			productName = Decimus;
 			productReference = 9BA27FC2297D7270007013B2 /* QuicR.app */;
@@ -887,7 +884,6 @@
 				FFA0E84E2A6F25A20027603B /* XCRemoteSwiftPackageReference "WrappingHStack" */,
 				188ABB542A792E9C00B31A6E /* XCRemoteSwiftPackageReference "swift-opus" */,
 				18BF45762B0E0F3D006E8E24 /* XCRemoteSwiftPackageReference "TPCircularBuffer" */,
-				9B8B6F662B9B01F700FBB0D1 /* XCRemoteSwiftPackageReference "swift-atomics" */,
 				9B81EEBD2C6A578C003690F9 /* XCRemoteSwiftPackageReference "SwiftLintPlugins" */,
 			);
 			productRefGroup = 9BA27FC3297D7270007013B2 /* Products */;
@@ -1539,14 +1535,6 @@
 				minimumVersion = 0.56.1;
 			};
 		};
-		9B8B6F662B9B01F700FBB0D1 /* XCRemoteSwiftPackageReference "swift-atomics" */ = {
-			isa = XCRemoteSwiftPackageReference;
-			repositoryURL = "https://github.com/apple/swift-atomics.git";
-			requirement = {
-				kind = upToNextMajorVersion;
-				minimumVersion = 1.2.0;
-			};
-		};
 		9BDD5B11299697DE00C01D54 /* XCRemoteSwiftPackageReference "swift-collections" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/apple/swift-collections.git";
@@ -1590,11 +1578,6 @@
 			isa = XCSwiftPackageProductDependency;
 			package = 9B81EEBD2C6A578C003690F9 /* XCRemoteSwiftPackageReference "SwiftLintPlugins" */;
 			productName = "plugin:SwiftLintBuildToolPlugin";
-		};
-		9B8B6F672B9B01F700FBB0D1 /* Atomics */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = 9B8B6F662B9B01F700FBB0D1 /* XCRemoteSwiftPackageReference "swift-atomics" */;
-			productName = Atomics;
 		};
 		9BC070D22D2C37AD00FE5B0E /* SwiftLintBuildToolPlugin */ = {
 			isa = XCSwiftPackageProductDependency;

--- a/QuicR.xcodeproj/project.pbxproj
+++ b/QuicR.xcodeproj/project.pbxproj
@@ -64,6 +64,8 @@
 		9B2B281A2D37CDBA00A80593 /* Fetch.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B2B28192D37CDB900A80593 /* Fetch.swift */; };
 		9B2B281E2D37D46500A80593 /* CallbackFetch.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B2B281D2D37D45E00A80593 /* CallbackFetch.swift */; };
 		9B308B992CAAEE7400BF2361 /* LabeledToggle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B308B982CAAEE6F00BF2361 /* LabeledToggle.swift */; };
+		9B3726932D8065B400498550 /* Mutex+Convenience.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B3726922D8065A900498550 /* Mutex+Convenience.swift */; };
+		9B3726952D806F5800498550 /* TestMutex+Convenience.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B3726942D806F5000498550 /* TestMutex+Convenience.swift */; };
 		9B3E44172C8F1FD60000B98D /* Publication.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B3E44162C8F1FD60000B98D /* Publication.swift */; };
 		9B3F86852C58F4B800B5B8BA /* CircularBuffer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B3F86842C58F4B800B5B8BA /* CircularBuffer.swift */; };
 		9B4788D42B972F990056CE7E /* TestVideoSubscriptionSet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B4788D32B972F990056CE7E /* TestVideoSubscriptionSet.swift */; };
@@ -261,6 +263,8 @@
 		9B2B28192D37CDB900A80593 /* Fetch.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Fetch.swift; sourceTree = "<group>"; };
 		9B2B281D2D37D45E00A80593 /* CallbackFetch.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CallbackFetch.swift; sourceTree = "<group>"; };
 		9B308B982CAAEE6F00BF2361 /* LabeledToggle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LabeledToggle.swift; sourceTree = "<group>"; };
+		9B3726922D8065A900498550 /* Mutex+Convenience.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Mutex+Convenience.swift"; sourceTree = "<group>"; };
+		9B3726942D806F5000498550 /* TestMutex+Convenience.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "TestMutex+Convenience.swift"; sourceTree = "<group>"; };
 		9B3E44162C8F1FD60000B98D /* Publication.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Publication.swift; sourceTree = "<group>"; };
 		9B3F86842C58F4B800B5B8BA /* CircularBuffer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CircularBuffer.swift; sourceTree = "<group>"; };
 		9B4788D32B972F990056CE7E /* TestVideoSubscriptionSet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestVideoSubscriptionSet.swift; sourceTree = "<group>"; };
@@ -506,6 +510,7 @@
 		9B85951C29F04521008C813C /* Tests */ = {
 			isa = PBXGroup;
 			children = (
+				9B3726942D806F5000498550 /* TestMutex+Convenience.swift */,
 				9B156EFF2D64AB0E00E91D0F /* TestSlidingWindow.swift */,
 				9B7325EE2D558C3900729DFB /* MockClient.swift */,
 				9B7B26912D367B3C00A29CFA /* TestSubscription.swift */,
@@ -586,6 +591,7 @@
 		9BA27FC4297D7270007013B2 /* Decimus */ = {
 			isa = PBXGroup;
 			children = (
+				9B3726922D8065A900498550 /* Mutex+Convenience.swift */,
 				9B156EFD2D649EFE00E91D0F /* SlidingWindow.swift */,
 				9BB7FA202D53FF8000E90AAD /* mDNSLookup.swift */,
 				9BE6288D2CE4FCD3001401D0 /* ManualActiveSpeaker.swift */,
@@ -979,6 +985,7 @@
 				9B7325EF2D558C3B00729DFB /* MockClient.swift in Sources */,
 				9BC53E0B2B84E0150056C154 /* TestApplicationSEIs.swift in Sources */,
 				187DE36F2C997AFE0090FB68 /* TestOpusPublication.swift in Sources */,
+				9B3726952D806F5800498550 /* TestMutex+Convenience.swift in Sources */,
 				9B6138502C90893C006E5E11 /* TestPublication.swift in Sources */,
 				187DE3732C997D2F0090FB68 /* TestOpusSubscription.swift in Sources */,
 				9B4788D42B972F990056CE7E /* TestVideoSubscriptionSet.swift in Sources */,
@@ -1048,6 +1055,7 @@
 				FF4DA06D29FAEF4F00A01E5D /* ViewExtensions.swift in Sources */,
 				FFFF72D92A27FBEA00D4D5EE /* RelayConfig.swift in Sources */,
 				FFFF72DB2A280A8000D4D5EE /* RelaySettingsView.swift in Sources */,
+				9B3726932D8065B400498550 /* Mutex+Convenience.swift in Sources */,
 				FF01709629C10013000E23A6 /* FormInput.swift in Sources */,
 				FF6D6D792A0422CE00B535DA /* CodecFactory.swift in Sources */,
 				9B48068929829FB90040F5D4 /* VideoParticipant.swift in Sources */,

--- a/QuicR.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/QuicR.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "e5d00282b90ec59408c99c73849de7d96c4d38bfbc0d6416d86320d2ff39d1db",
+  "originHash" : "c58a777c81c3249a778bb0ccbb86dfc6a8ef76b52541c5fb16d9de9828b8ffd5",
   "pins" : [
     {
       "identity" : "csv.swift",
@@ -26,15 +26,6 @@
       "state" : {
         "revision" : "6f79af75a7958142add2e811dc0a6a6ae6507bd2",
         "version" : "1.7.0"
-      }
-    },
-    {
-      "identity" : "swift-atomics",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-atomics.git",
-      "state" : {
-        "revision" : "cd142fd2f64be2100422d658e7411e39489da985",
-        "version" : "1.2.0"
       }
     },
     {

--- a/Tests/TestMutex+Convenience.swift
+++ b/Tests/TestMutex+Convenience.swift
@@ -1,0 +1,34 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025 Cisco Systems
+// SPDX-License-Identifier: BSD-2-Clause
+
+import Synchronization
+import Testing
+
+struct MutexTests {
+    private class Example {
+        var value = 0
+    }
+    private typealias MutexCall = (borrowing Mutex<Example?>) -> Void
+    private enum ClearType { case native, custom }
+    private static let native: MutexCall = { $0.withLock { $0 = nil } }
+    private static let custom: MutexCall = { $0.clear() }
+    private static let dict: [ClearType: MutexCall] = [.native: native, .custom: custom]
+
+    @Test("Safe Retrieval", arguments: [ClearType.native, ClearType.custom])
+    private func safeRetrieval(_ call: ClearType) {
+        let mutex = Mutex<Example?>(.init())
+        mutex.withLock { $0!.value += 1 }
+
+        let arcSafe = mutex.get()
+        #expect(arcSafe != nil)
+        #expect(arcSafe!.value == 1)
+
+        mutex.withLock { $0!.value += 1 }
+        #expect(arcSafe != nil)
+        #expect(arcSafe!.value == 2)
+
+        Self.dict[call]?(mutex)
+        #expect(arcSafe != nil)
+        #expect(arcSafe!.value == 2)
+    }
+}


### PR DESCRIPTION
Closes #587 by removing `swift-atomics` in favour of the builtins provided in `Synchronization` and remove OS locks in favour of type safe `Mutex<T>`