### PR TITLE
Hotfix accidental strong reference

### DIFF
--- a/Config.xcconfig
+++ b/Config.xcconfig
@@ -4,4 +4,4 @@
 // Configuration settings file format documentation can be found at:
 // https://help.apple.com/xcode/#/dev745c5c974
 
-APP_VERSION=4.7.0
+APP_VERSION=4.7.1

--- a/Decimus/DecimusAudioEngine.swift
+++ b/Decimus/DecimusAudioEngine.swift
@@ -74,8 +74,9 @@ class DecimusAudioEngine {
         Self.logger.warning("Media services reset. Report this.")
     }
 
-    private lazy var routeChange: (Notification) -> Void = { notification in
-        guard let userInfo = notification.userInfo,
+    private lazy var routeChange: (Notification) -> Void = { [weak self] notification in
+        guard let self = self,
+              let userInfo = notification.userInfo,
               let reasonValue = userInfo[AVAudioSessionRouteChangeReasonKey] as? UInt,
               let reason = AVAudioSession.RouteChangeReason(rawValue: reasonValue) else {
             return


### PR DESCRIPTION
Route change notification was holding onto the audio engine, and keeping the mic capture up. 