### PR TITLE
Fixup SwiftUI import

### DIFF
--- a/Config.xcconfig
+++ b/Config.xcconfig
@@ -4,4 +4,4 @@
 // Configuration settings file format documentation can be found at:
 // https://help.apple.com/xcode/#/dev745c5c974
 
-APP_VERSION=4.13.2
+APP_VERSION=4.13.3

--- a/Decimus/Views/Components/ObservableSubscriptionDetails.swift
+++ b/Decimus/Views/Components/ObservableSubscriptionDetails.swift
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2023 Cisco Systems
 // SPDX-License-Identifier: BSD-2-Clause
 
-import SwiftUICore
+import SwiftUI
 
 struct ObservableSubscriptionSetDetails: View {
     var observable: ObservableSubscriptionSet

--- a/Decimus/Views/Components/PublicationPopover.swift
+++ b/Decimus/Views/Components/PublicationPopover.swift
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2023 Cisco Systems
 // SPDX-License-Identifier: BSD-2-Clause
 
-import SwiftUICore
+import SwiftUI
 
 struct PublicationPopover: View {
     private let controller: MoqCallController

--- a/Decimus/Views/Components/SubscriptionPopover.swift
+++ b/Decimus/Views/Components/SubscriptionPopover.swift
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2023 Cisco Systems
 // SPDX-License-Identifier: BSD-2-Clause
 
-import SwiftUICore
+import SwiftUI
 
 struct SubscriptionPopover: View {
     private let controller: MoqCallController

--- a/Decimus/Views/Components/ViewExtensions.swift
+++ b/Decimus/Views/Components/ViewExtensions.swift
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2023 Cisco Systems
 // SPDX-License-Identifier: BSD-2-Clause
 
-import SwiftUICore
+import SwiftUI
 #if canImport(UIKit)
 import UIKit
 #endif


### PR DESCRIPTION
`SwiftUICore` not allowed in iOS26