### PR TITLE
Show traversal time in stats

### DIFF
--- a/Config.xcconfig
+++ b/Config.xcconfig
@@ -4,4 +4,4 @@
 // Configuration settings file format documentation can be found at:
 // https://help.apple.com/xcode/#/dev745c5c974
 
-APP_VERSION=5.2.0
+APP_VERSION=5.3.0

--- a/Decimus/AppHeaderRegistry.swift
+++ b/Decimus/AppHeaderRegistry.swift
@@ -4,11 +4,13 @@
 enum AppHeaderRegistry {
     case energyLevel
     case participantId
+    case publishTimestamp
 
     private var uintValue: UInt {
         switch self {
-        case .energyLevel: return 6
-        case .participantId: return 8
+        case .energyLevel: 6
+        case .participantId: 8
+        case .publishTimestamp: 10
         }
     }
 
@@ -23,6 +25,8 @@ enum AppHeaderRegistry {
             self = .energyLevel
         case AppHeaderRegistry.participantId.uintValue:
             self = .participantId
+        case AppHeaderRegistry.publishTimestamp.uintValue:
+            self = .publishTimestamp
         default:
             return nil
         }

--- a/Decimus/Lib/libquicr/LowOverheadContainer.swift
+++ b/Decimus/Lib/libquicr/LowOverheadContainer.swift
@@ -66,6 +66,13 @@ class LowOverheadContainer {
         return self.extensions[key]
     }
 
+    /// Get a value from the container.
+    /// - Parameter key: Key to retrieve.
+    /// - Returns: Value associated with the key, if any.
+    func get(key: AppHeaderRegistry) -> Data? {
+        self.get(key: key.rawValue)
+    }
+
     /// Parse a LOC from a MoQ header extension dictionary.
     /// - Throws: ``LowOverheadContainerError/missingField`` if a mandatory field is missing.
     init(from extensions: [NSNumber: Data]) throws {

--- a/Decimus/Publications/H264Publication.swift
+++ b/Decimus/Publications/H264Publication.swift
@@ -69,6 +69,8 @@ class H264Publication: Publication, FrameListener {
 
         // Use extensions for LOC.
         let loc = LowOverheadContainer(timestamp: presentationDate, sequence: sequence)
+        let now = UInt64(Date.now.timeIntervalSince1970 * 1000)
+        loc.add(key: .publishTimestamp, value: withUnsafeBytes(of: now) { Data($0) })
 
         // Publish.
         let data = Data(bytesNoCopy: .init(mutating: data.baseAddress!),

--- a/Decimus/Subscriptions/SubscriptionFactory.swift
+++ b/Decimus/Subscriptions/SubscriptionFactory.swift
@@ -362,13 +362,9 @@ class SubscriptionFactoryImpl: SubscriptionFactory {
                                          subscriptionConfig: .init(joinConfig: joinConfig,
                                                                    calculateLatency: self.calculateLatency),
                                          sframeContext: self.sframeContext,
-                                         callback: { [weak set] timestamp, when, cached, _, usable in
+                                         callback: { [weak set] details in
                                             guard let set = set else { return }
-                                            set.receivedObject(ftn,
-                                                               timestamp: timestamp,
-                                                               when: when,
-                                                               cached: cached,
-                                                               usable: usable)
+                                            set.receivedObject(ftn, details: details)
                                          },
                                          statusChanged: unregister)
         } else if config is AudioCodecConfig {

--- a/Decimus/Subscriptions/VideoSubscription.swift
+++ b/Decimus/Subscriptions/VideoSubscription.swift
@@ -33,7 +33,7 @@ class VideoSubscription: Subscription {
     private let jitterBufferConfig: JitterBuffer.Config
     private let simulreceive: SimulreceiveMode
     private let variances: VarianceCalculator
-    private let callback: ObjectReceived
+    private let callback: ObjectReceivedCallback
     private var token: Int = 0
     private let logger = DecimusLogger(VideoSubscription.self)
     private let verbose: Bool
@@ -131,7 +131,7 @@ class VideoSubscription: Subscription {
          cleanupTime: TimeInterval,
          subscriptionConfig: Config,
          sframeContext: SFrameContext?,
-         callback: @escaping ObjectReceived,
+         callback: @escaping ObjectReceivedCallback,
          statusChanged: @escaping StatusChanged) throws {
         self.fullTrackName = try profile.getFullTrackName()
         self.config = config

--- a/Decimus/Views/Components/VideoGrid.swift
+++ b/Decimus/Views/Components/VideoGrid.swift
@@ -127,6 +127,15 @@ struct VideoGrid: View {
                                                             .fontDesign(.monospaced)
                                                     }
                                                 }
+                                                if let average = latencies.traversal.average {
+                                                    HStack {
+                                                        Text("MoQ Traversal Time: ")
+                                                        let formatted = String(format: "%.2f",
+                                                                               average * 1000)
+                                                        Text("\(formatted)ms")
+                                                            .fontDesign(.monospaced)
+                                                    }
+                                                }
                                             }
                                         }
                                         .background()

--- a/Tests/TestVideoSubscription.swift
+++ b/Tests/TestVideoSubscription.swift
@@ -27,7 +27,7 @@ struct TestVideoSubscription {
     private func makeSubscription(_ mockClient: MockClient,
                                   fetchThreshold: UInt64,
                                   ngThreshold: UInt64,
-                                  callback: ObjectReceived? = nil) async throws -> VideoSubscription {
+                                  callback: ObjectReceivedCallback? = nil) async throws -> VideoSubscription {
         let controller = MoqCallController(endpointUri: "",
                                            client: mockClient,
                                            submitter: nil,
@@ -63,7 +63,7 @@ struct TestVideoSubscription {
                                                                                  newGroupUpperThreshold: ngThreshold),
                                                                calculateLatency: false),
                                      sframeContext: nil,
-                                     callback: { callback?($0, $1, $2, $3, $4) },
+                                     callback: { callback?($0) },
                                      statusChanged: ({_ in }))
     }
 
@@ -212,10 +212,10 @@ struct TestVideoSubscription {
         var gotGroupId: UInt64?
         var gotObjectId: UInt64?
         var shouldDrop: Bool?
-        let callback: ObjectReceived = { _, _, _, headers, usable in
-            shouldDrop = !usable
-            gotGroupId = headers.groupId
-            gotObjectId = headers.objectId
+        let callback: ObjectReceivedCallback = { details in
+            shouldDrop = !details.usable
+            gotGroupId = details.headers.groupId
+            gotObjectId = details.headers.objectId
         }
 
         let mockClient = MockClient(publish: { _ in },

--- a/Tests/TestVideoSubscriptionSet.swift
+++ b/Tests/TestVideoSubscriptionSet.swift
@@ -182,11 +182,19 @@ struct VideoSubscriptionSetTests {
                                            cleanupTime: 10,
                                            slidingWindowTime: 10,
                                            config: .init(calculateLatency: false))
+        let details = ObjectReceived(timestamp: timestamp,
+                                     when: Self.now,
+                                     cached: false,
+                                     headers: .init(groupId: 0,
+                                                    objectId: 0,
+                                                    payloadLength: 0,
+                                                    priority: nil,
+                                                    ttl: nil),
+                                     usable: true,
+                                     publishTimestamp: nil)
+
         try set.receivedObject(.init(namespace: [], name: ""),
-                               timestamp: timestamp,
-                               when: Self.now,
-                               cached: false,
-                               usable: true)
+                               details: details)
     }
 }
 


### PR DESCRIPTION
Adds the "MoQ Traversal Time" to the in-call stats. This is the difference between the time at client publish vs the time at client receive. 