### PR TITLE
Disable keyframe on subscribe update

### DIFF
--- a/Config.xcconfig
+++ b/Config.xcconfig
@@ -4,4 +4,4 @@
 // Configuration settings file format documentation can be found at:
 // https://help.apple.com/xcode/#/dev745c5c974
 
-APP_VERSION=7.0.1
+APP_VERSION=7.1.0

--- a/Decimus/CallState.swift
+++ b/Decimus/CallState.swift
@@ -182,7 +182,7 @@ class CallState: ObservableObject, Equatable {
                                                         keyFrameInterval: subConfig.keyFrameInterval,
                                                         stagger: subConfig.stagger,
                                                         verbose: self.verbose,
-                                                        keyFrameOnUpdate: subConfig.keyFrameOnUpdate,
+                                                        keyFrameOnUpdate: subConfig.keyFrameOnSubscribeUpdate,
                                                         startingGroup: self.audioStartingGroup,
                                                         sframeContext: self.sendContext)
         let playtime = self.playtimeConfig.value

--- a/Decimus/Subscriptions/SubscriptionFactory.swift
+++ b/Decimus/Subscriptions/SubscriptionFactory.swift
@@ -111,7 +111,7 @@ struct SubscriptionConfig: Codable {
     /// SFrame encryption of media settings.
     var sframeSettings: SFrameSettings
     /// True to publish keyframe on subscribe update.
-    var keyFrameOnUpdate: Bool
+    var keyFrameOnSubscribeUpdate: Bool
     /// Time to cleanup stale subscriptions for.
     var cleanupTime: TimeInterval
     /// Stream join time rules.
@@ -121,7 +121,7 @@ struct SubscriptionConfig: Codable {
     init() {
         jitterMaxTime = 1
         jitterDepthTime = 0.2
-        useNewJitterBuffer = false
+        self.useNewJitterBuffer = true
         opusWindowSize = .twentyMs
         self.audioPlcLimit = 6
         self.playoutBufferTime = 0.02
@@ -146,7 +146,7 @@ struct SubscriptionConfig: Codable {
         quicPriorityLimit = 0
         self.sframeSettings = .init()
         stagger = true
-        self.keyFrameOnUpdate = true
+        self.keyFrameOnSubscribeUpdate = false
         self.cleanupTime = 1.5
         self.joinConfig = .init(fetchUpperThreshold: 1, newGroupUpperThreshold: 4)
     }

--- a/Decimus/Views/Settings/SubscriptionSettingsView.swift
+++ b/Decimus/Views/Settings/SubscriptionSettingsView.swift
@@ -70,8 +70,13 @@ struct SubscriptionSettingsView: View {
                             .labelsHidden()
                     }
                 }
-                LabeledToggle("KeyFrame on Update",
-                              isOn: self.$subscriptionConfig.value.keyFrameOnUpdate)
+                LabeledToggle("Key Frame on Update",
+                              isOn: self.$subscriptionConfig.value.keyFrameOnSubscribeUpdate)
+                if self.subscriptionConfig.value.keyFrameOnSubscribeUpdate {
+                    Text("I hope you know what you're doing 😅")
+                        .font(.footnote)
+                        .foregroundStyle(.secondary)
+                }
 
                 LabeledContent("Fetch before (s)") {
                     TextField(


### PR DESCRIPTION
- Disable key frame request on subscribe update by default, but leave the code paths for now. 
- Since we're rev'ing the defaults, take the opportunity to graduate the new audio buffer to default. 