### PR TITLE
Move all app header extensions to immutable

### DIFF
--- a/Decimus/Publications/H264Publication.swift
+++ b/Decimus/Publications/H264Publication.swift
@@ -198,8 +198,8 @@ class H264Publication: Publication, FrameListener {
                                         data: protected,
                                         priority: &priority,
                                         ttl: &ttl,
-                                        extensions: extensions,
-                                        immutableExtensions: nil),
+                                        extensions: nil,
+                                        immutableExtensions: extensions),
                     protected.count)
         }
         switch status.0 {

--- a/Decimus/Publications/OpusPublication.swift
+++ b/Decimus/Publications/OpusPublication.swift
@@ -259,7 +259,7 @@ class OpusPublication: Publication, AudioPublication {
         let extensions = try self.getExtensions(wallClock: wallClock,
                                                 dequeuedTimestamp: dequeued.timestamp,
                                                 decibel: decibel)
-        return .init(encodedData: encoded, extensions: extensions, immutableExtensions: nil)
+        return .init(encodedData: encoded, extensions: nil, immutableExtensions: extensions)
     }
 
     private func getAudioLevel(_ buffer: AVAudioPCMBuffer) throws -> Int {

--- a/Decimus/Publications/TextPublication.swift
+++ b/Decimus/Publications/TextPublication.swift
@@ -65,8 +65,8 @@ class TextPublication: Publication {
         try? extensions.setHeader(.participantId(self.participantId))
         let status = self.publishObject(headers,
                                         data: data,
-                                        extensions: extensions,
-                                        immutableExtensions: nil)
+                                        extensions: nil,
+                                        immutableExtensions: extensions)
         switch status {
         case .ok:
             break

--- a/Decimus/Subscriptions/ActiveSpeakerSubscriptionSet.swift
+++ b/Decimus/Subscriptions/ActiveSpeakerSubscriptionSet.swift
@@ -40,13 +40,13 @@ class ActiveSpeakerSubscriptionSet: ObservableSubscriptionSet {
                         extensions: HeaderExtensions?,
                         immutableExtensions: HeaderExtensions?) {
         // Extract the client ID from the header.
-        guard let extensions = extensions else {
+        guard let immutableExtensions else {
             self.logger.error("Missing expected extensions")
             return
         }
 
         // Parse.
-        guard let participantIdExtension = try? extensions.getHeader(AppHeadersRegistry.participantId),
+        guard let participantIdExtension = try? immutableExtensions.getHeader(AppHeadersRegistry.participantId),
               case .participantId(let participantId) = participantIdExtension else {
             self.logger.error("Missing participant ID extension")
             return
@@ -96,7 +96,7 @@ class ActiveSpeakerSubscriptionSet: ObservableSubscriptionSet {
         }
 
         // Decode the LOC here.
-        guard let captureTimestampExtension = try? extensions.getHeader(.captureTimestamp),
+        guard let captureTimestampExtension = try? immutableExtensions.getHeader(.captureTimestamp),
               case .captureTimestamp(let captureTimestamp) = captureTimestampExtension else {
             self.logger.error("Missing capture timestamp extension")
             return

--- a/Decimus/Subscriptions/OpusSubscription.swift
+++ b/Decimus/Subscriptions/OpusSubscription.swift
@@ -143,7 +143,7 @@ class OpusSubscription: Subscription {
         // Metrics.
         let date: Date? = self.granularMetrics ? now : nil
 
-        guard let extensions = extensions else {
+        guard let immutableExtensions else {
             Self.logger.warning("Missing expected extensions")
             return
         }
@@ -151,7 +151,7 @@ class OpusSubscription: Subscription {
         let sequence: UInt64
         let timestamp: Date
         do {
-            let (seq, time) = try self.parseExtensionHeaders(extensions)
+            let (seq, time) = try self.parseExtensionHeaders(immutableExtensions)
             sequence = seq ?? objectHeaders.groupId
             timestamp = time
         } catch {
@@ -161,7 +161,7 @@ class OpusSubscription: Subscription {
 
         // Active speaker metric.
         if let activeSpeakerStats = self.activeSpeakerStats,
-           let participantId = try? extensions.getHeader(.participantId),
+           let participantId = try? immutableExtensions.getHeader(.participantId),
            case .participantId(let id) = participantId {
             Task(priority: .utility) {
                 await activeSpeakerStats.audioDetected(id, when: now)

--- a/Decimus/Subscriptions/TextSubscriptions.swift
+++ b/Decimus/Subscriptions/TextSubscriptions.swift
@@ -46,8 +46,8 @@ class TextSubscriptions {
                           immutableExtensions: HeaderExtensions?) {
         // Try and get participant ID.
         let participantId: ParticipantId?
-        if let extensions,
-           let participantIdData = try? extensions.getHeader(.participantId),
+        if let immutableExtensions,
+           let participantIdData = try? immutableExtensions.getHeader(.participantId),
            case .participantId(let id) = participantIdData {
             participantId = id
         } else {

--- a/Decimus/Subscriptions/VideoSubscription.swift
+++ b/Decimus/Subscriptions/VideoSubscription.swift
@@ -364,7 +364,7 @@ class VideoSubscription: Subscription {
         func notify(drop: Bool) {
             handler.objectReceived(objectHeaders,
                                    data: unprotected,
-                                   extensions: extensions,
+                                   extensions: immutableExtensions,
                                    when: now,
                                    cached: false,
                                    drop: drop)

--- a/Tests/TestVideoSubscription.swift
+++ b/Tests/TestVideoSubscription.swift
@@ -232,7 +232,7 @@ struct TestVideoSubscription {
         }
 
         // Get into waiting for new group state.
-        subscription.mockObject(groupId: sentGroupId, objectId: sendObjectId, extensions: loc())
+        subscription.mockObject(groupId: sentGroupId, objectId: sendObjectId, extensions: nil, immutableExtensions: loc())
         #expect(shouldDrop == true)
         #expect(gotGroupId == sentGroupId)
         #expect(gotObjectId == sendObjectId)
@@ -240,7 +240,7 @@ struct TestVideoSubscription {
         // We want to validate that when we're waiting for a new group,
         // we drop middle of group objects.
         sendObjectId += 1
-        subscription.mockObject(groupId: sentGroupId, objectId: sendObjectId, extensions: loc())
+        subscription.mockObject(groupId: sentGroupId, objectId: sendObjectId, extensions: nil, immutableExtensions: loc())
         #expect(shouldDrop == true)
         #expect(gotGroupId == sentGroupId)
         #expect(gotObjectId == sendObjectId)
@@ -248,7 +248,7 @@ struct TestVideoSubscription {
         // When a new group does arrive, we use it.
         sentGroupId += 1
         sendObjectId = 0
-        subscription.mockObject(groupId: sentGroupId, objectId: sendObjectId, extensions: loc())
+        subscription.mockObject(groupId: sentGroupId, objectId: sendObjectId, extensions: nil, immutableExtensions: loc())
         #expect(shouldDrop == false)
         #expect(gotGroupId == sentGroupId)
         #expect(gotObjectId == sendObjectId)


### PR DESCRIPTION
Moves all app specific media headers to immutable. This is a breaking change. 