### PR TITLE
Fix tests for CanPublish

### DIFF
--- a/Config.xcconfig
+++ b/Config.xcconfig
@@ -4,4 +4,4 @@
 // Configuration settings file format documentation can be found at:
 // https://help.apple.com/xcode/#/dev745c5c974
 
-APP_VERSION=8.6.1
+APP_VERSION=8.6.2


### PR DESCRIPTION
While the application logic was correct, the video encoding local tests were failing as they were still mocking status changes rather than mocking CanPublish() results. Updated to fix. 