### PR TITLE
Report video traversal time to influx

### DIFF
--- a/Config.xcconfig
+++ b/Config.xcconfig
@@ -4,4 +4,4 @@
 // Configuration settings file format documentation can be found at:
 // https://help.apple.com/xcode/#/dev745c5c974
 
-APP_VERSION=8.8.1
+APP_VERSION=8.9.0

--- a/Decimus/Measurements/VideoHandler+Measurement.swift
+++ b/Decimus/Measurements/VideoHandler+Measurement.swift
@@ -71,5 +71,9 @@ extension VideoHandler {
         func frameDelay(delay: TimeInterval, metricsTimestamp: Date) {
             record(field: "delay", value: delay, timestamp: metricsTimestamp)
         }
+
+        func moqTraversalTime(time: TimeInterval, metricsTimestamp: Date) {
+            self.record(field: "traversalTime", value: time, timestamp: metricsTimestamp)
+        }
     }
 }

--- a/Decimus/Publications/H264Publication.swift
+++ b/Decimus/Publications/H264Publication.swift
@@ -218,6 +218,9 @@ class H264Publication: MoQSinkDelegate, FrameListener, PublicationInstance {
                 publication.logger.error("Malformed profile")
                 return (QPublishObjectStatus.internalError, 0)
             }
+            if publication.granularMetrics {
+                try extensions.setHeader(.publishTimestamp(.now))
+            }
             return (publication.publish(groupId: thisGroupId,
                                         objectId: thisObjectId,
                                         data: protected,

--- a/Decimus/Subscriptions/VideoHandler.swift
+++ b/Decimus/Subscriptions/VideoHandler.swift
@@ -416,6 +416,14 @@ class VideoHandler: TimeAlignable, CustomStringConvertible { // swiftlint:disabl
             if let publishTimestampDate = try? extensions.getHeader(.publishTimestamp),
                case .publishTimestamp(let extracted) = publishTimestampDate {
                 publishTimestamp = extracted
+                if self.granularMetrics,
+                   let measurement = self.measurement?.measurement {
+                    let now = when.hostDate
+                    let traversal = now.timeIntervalSince(extracted)
+                    Task(priority: .utility) {
+                        await measurement.moqTraversalTime(time: traversal, metricsTimestamp: now)
+                    }
+                }
             } else {
                 publishTimestamp = nil
             }


### PR DESCRIPTION
Add ability to calculate / send to influx the MoQ "traversal time" (time from app publish to app receive). 